### PR TITLE
Bug fixes, small feature enhancements and activity alert dialog

### DIFF
--- a/src/main/java/org/intellij/sdk/codesync/Constants.java
+++ b/src/main/java/org/intellij/sdk/codesync/Constants.java
@@ -5,6 +5,7 @@ import org.intellij.sdk.codesync.configuration.Configuration;
 import org.intellij.sdk.codesync.configuration.ConfigurationFactory;
 
 import java.nio.file.Paths;
+import java.time.ZoneId;
 
 public final class Constants {
     public static final Configuration configuration = ConfigurationFactory.getConfiguration();
@@ -39,7 +40,10 @@ public final class Constants {
     public static final String[] IGNORABLE_DIRECTORIES = new String[]{".git", "node_modules", ".DS_Store", ".idea"};
     public static final String CURRENT_GIT_BRANCH_COMMAND = "git rev-parse --abbrev-ref HEAD";
     public static final Integer DELAY_BETWEEN_BUFFER_TASKS = 5000;
+
+    public static final String DEFAULT_TIMEZONE = ZoneId.systemDefault().getId();
     public static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS z";
+    public static final String DATE_TIME_FORMAT_WITHOUT_TIMEZONE = "yyyy-MM-dd HH:mm:ss.SSS";
     public static final String IDE_NAME = ApplicationInfo.getInstance().getVersionName();
     public static final String DIFF_SOURCE = "intellij";
     public static final String GA4_PARAMS = String.format("utm_medium=plugin&utm_source=%s&utm_source_platform=%s", DIFF_SOURCE, IDE_NAME);
@@ -62,6 +66,7 @@ public final class Constants {
     public static final String API_USERS = String.format("%s/users", API_ENDPOINT);
     public static final String CODESYNC_REPO_URL = String.format("%s/repos", API_ENDPOINT);
     public static final String FILES_API_ENDPOINT = String.format("%s/files", API_ENDPOINT);
+    public static final String TEAM_ACTIVITY_ENDPOINT = String.format("%s/team_activity?tz=%s", API_ENDPOINT, DEFAULT_TIMEZONE);
 
     public static final String API_HEALTHCHECK = String.format("%s/healthcheck", CODESYNC_HOST);
     public static final String CODESYNC_AUTHORIZE_URL = String.format("%s/authorize", CODESYNC_HOST);
@@ -92,6 +97,7 @@ public final class Constants {
     public static final String DIFFS_DAEMON_LOCK_KEY = "send_diffs_intellij";
     public static final String POPULATE_BUFFER_DAEMON_LOCK_KEY = "populate_buffer";
     public static final String PRICING_ALERT_LOCK_KEY = "pricing_alert";
+    public static final String TEAM_ACTIVITY_ALERT_LOCK_KEY = "team_activity_alert";
 
     public static final class PlatformIdentifier {
         private PlatformIdentifier() {
@@ -140,6 +146,12 @@ public final class Constants {
         public static final String UPGRADE_ORG_PRICING_PLAN = "To continue, please sign your organization up for the Team plan.";
         public static final String TRY_PRO_FOR_FREE = "To continue, please sign up for a 30-day free trial of Pro.";
         public static final String TRY_ORG_PRO_FOR_FREE = "To continue, please sign your organization up for a 30-day free trial of the Team plan.";
+
+        // Team alert related notification messages
+        public static final String TEAM_ACTIVITY_ALERT_HEADER_MESSAGE = "CodeSync | Check your team's activity!";
+        public static final String TEAM_ACTIVITY_ALERT_MESSAGE = "Hey, check your team's activity!";
+        public static final String TEAM_ACTIVITY_ALERT_SECONDARY_MESSAGE =
+            "If you are available right now then you can either skip for today or review later by clicking the correct button below.";
     }
 
     public static final class LogMessageType {

--- a/src/main/java/org/intellij/sdk/codesync/Constants.java
+++ b/src/main/java/org/intellij/sdk/codesync/Constants.java
@@ -97,7 +97,7 @@ public final class Constants {
     public static final String DIFFS_DAEMON_LOCK_KEY = "send_diffs_intellij";
     public static final String POPULATE_BUFFER_DAEMON_LOCK_KEY = "populate_buffer";
     public static final String PRICING_ALERT_LOCK_KEY = "pricing_alert";
-    public static final String TEAM_ACTIVITY_ALERT_LOCK_KEY = "team_activity_alert";
+    public static final String ACTIVITY_ALERT_LOCK_KEY = "activity_alerts";
 
     public static final class PlatformIdentifier {
         private PlatformIdentifier() {
@@ -148,10 +148,14 @@ public final class Constants {
         public static final String TRY_ORG_PRO_FOR_FREE = "To continue, please sign your organization up for a 30-day free trial of the Team plan.";
 
         // Team alert related notification messages
+        public static final String ACTIVITY_ALERT_HEADER_MESSAGE = "CodeSync | Check your activity!";
+        public static final String ACTIVITY_ALERT_MESSAGE = "Hope you had a great day! Shall we review today's code playback?";
+        public static final String ACTIVITY_ALERT_SECONDARY_MESSAGE =
+            "If you are not available right now then you can either skip for today or review later by clicking the correct button below.";
         public static final String TEAM_ACTIVITY_ALERT_HEADER_MESSAGE = "CodeSync | Check your team's activity!";
-        public static final String TEAM_ACTIVITY_ALERT_MESSAGE = "Hey, check your team's activity!";
+        public static final String TEAM_ACTIVITY_ALERT_MESSAGE = "Hope you had a great day! It's time to get in sync with your team's code.";
         public static final String TEAM_ACTIVITY_ALERT_SECONDARY_MESSAGE =
-            "If you are available right now then you can either skip for today or review later by clicking the correct button below.";
+            "If you are not available right now then you can either skip for today or review later by clicking the correct button below.";
     }
 
     public static final class LogMessageType {

--- a/src/main/java/org/intellij/sdk/codesync/Constants.java
+++ b/src/main/java/org/intellij/sdk/codesync/Constants.java
@@ -127,6 +127,8 @@ public final class Constants {
         public static final String REPO_IN_SYNC_MESSAGE = "Repo '%s' is synced with CodeSync.";
         public static final String REPO_ALREADY_IN_SYNC_MESSAGE = "Repo '%s' is already being synced with CodeSync.";
 
+        public static final String LOGIN_REQUIRED_FOR_SYNC_MESSAGE = "You need to login to sync repo. Please login and then try again.";
+
         public static final String REPO_UNSYNC_CONFIRMATION = "Are you sure to continue? You won't be able to revert this!";
         public static final String REPO_UNSYNCED = "Repo disconnected successfully";
         public static final String REPO_UNSYNC_FAILED = "Could not unsync the repo";

--- a/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
@@ -12,7 +12,7 @@ import org.intellij.sdk.codesync.repoManagers.OriginalsRepoManager;
 import org.intellij.sdk.codesync.repoManagers.ShadowRepoManager;
 import org.intellij.sdk.codesync.utils.CommonUtils;
 import org.intellij.sdk.codesync.utils.FileUtils;
-import org.intellij.sdk.codesync.utils.PricingAlerts;
+import org.intellij.sdk.codesync.alerts.PricingAlerts;
 
 import java.io.*;
 import java.nio.file.Path;

--- a/src/main/java/org/intellij/sdk/codesync/actions/FilePlaybackAction.java
+++ b/src/main/java/org/intellij/sdk/codesync/actions/FilePlaybackAction.java
@@ -26,11 +26,17 @@ import static org.intellij.sdk.codesync.Constants.FILE_PLAYBACK_LINK;
 public class FilePlaybackAction extends BaseModuleAction {
     @Override
     public void update(AnActionEvent e) {
+        Project project = e.getProject();
+        if (project ==  null) {
+            e.getPresentation().setEnabled(false);
+            return;
+        }
+
         // Only enable file playback button when some file is opened in the editor.
         try {
             VirtualFile virtualFile = e.getRequiredData(CommonDataKeys.PSI_FILE).getVirtualFile();
             e.getPresentation().setEnabled(
-                this.isRepoInSync(virtualFile, e.getProject())
+                this.isRepoInSync(virtualFile, project)
             );
         } catch (AssertionError | FileNotInModuleError error) {
             e.getPresentation().setEnabled(false);

--- a/src/main/java/org/intellij/sdk/codesync/actions/RepoPlaybackAction.java
+++ b/src/main/java/org/intellij/sdk/codesync/actions/RepoPlaybackAction.java
@@ -21,16 +21,22 @@ public class RepoPlaybackAction extends BaseModuleAction {
 
     @Override
     public void update(AnActionEvent e) {
+        Project project = e.getProject();
+        if (project ==  null) {
+            e.getPresentation().setEnabled(false);
+            return;
+        }
+
         // Check if any of the modules inside this project are synced with codesync or not.
         // We will show repo playback button if even a single repo is synced.
-        VirtualFile[] contentRoots = ProjectUtils.getAllContentRoots(e.getProject());
+        VirtualFile[] contentRoots = ProjectUtils.getAllContentRoots(project);
         if (contentRoots.length > 1) {
             // If more than one module are present in the project then a file must be open to show repo playback
             // this is needed because without the file we can not determine the correct repo to show.
             try {
                 VirtualFile virtualFile = e.getRequiredData(CommonDataKeys.PSI_FILE).getVirtualFile();
                 e.getPresentation().setEnabled(
-                    this.isRepoInSync(virtualFile, e.getProject())
+                    this.isRepoInSync(virtualFile, project)
                 );
             } catch (AssertionError | FileNotInModuleError error) {
                 e.getPresentation().setEnabled(false);
@@ -57,7 +63,7 @@ public class RepoPlaybackAction extends BaseModuleAction {
         }
         String repoPath, repoName;
 
-        VirtualFile[] contentRoots = ProjectUtils.getAllContentRoots(e.getProject());
+        VirtualFile[] contentRoots = ProjectUtils.getAllContentRoots(project);
         if (contentRoots.length > 1) {
             // If more than one module are present in the project then a file must be open to show repo playback
             // this is needed because without the file we can not determine the correct repo to show.

--- a/src/main/java/org/intellij/sdk/codesync/alerts/PricingAlerts.java
+++ b/src/main/java/org/intellij/sdk/codesync/alerts/PricingAlerts.java
@@ -56,7 +56,7 @@ public class PricingAlerts {
     public static boolean getPlanLimitReached() {
         CodeSyncLock pricingAlertLock = new CodeSyncLock(LockFileType.PROJECT_LOCK, PRICING_ALERT_LOCK_KEY);
 
-        // If we are able to acquire the lock then it means price limit is not reached.
-        return !pricingAlertLock.acquireLock(PRICING_ALERT_LOCK_KEY);
+        // If lock is acquired then it means price limit is reached.
+        return pricingAlertLock.isLockAcquired(PRICING_ALERT_LOCK_KEY);
     }
 }

--- a/src/main/java/org/intellij/sdk/codesync/alerts/PricingAlerts.java
+++ b/src/main/java/org/intellij/sdk/codesync/alerts/PricingAlerts.java
@@ -1,4 +1,4 @@
-package org.intellij.sdk.codesync.utils;
+package org.intellij.sdk.codesync.alerts;
 
 import com.intellij.openapi.project.Project;
 import org.intellij.sdk.codesync.clients.CodeSyncClient;

--- a/src/main/java/org/intellij/sdk/codesync/alerts/TeamActivityAlerts.java
+++ b/src/main/java/org/intellij/sdk/codesync/alerts/TeamActivityAlerts.java
@@ -1,0 +1,96 @@
+package org.intellij.sdk.codesync.alerts;
+
+import com.intellij.openapi.project.Project;
+import org.intellij.sdk.codesync.Constants;
+import org.intellij.sdk.codesync.clients.CodeSyncClient;
+import org.intellij.sdk.codesync.files.UserFile;
+import org.intellij.sdk.codesync.locks.CodeSyncLock;
+import org.intellij.sdk.codesync.ui.dialogs.TeamActivityAlertDialog;
+import org.intellij.sdk.codesync.utils.DataUtils;
+import org.json.simple.JSONObject;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.intellij.sdk.codesync.Constants.TEAM_ACTIVITY_ALERT_LOCK_KEY;
+import static org.intellij.sdk.codesync.Constants.WEBAPP_DASHBOARD_URL;
+
+public class TeamActivityAlerts {
+    private static void acquireTeamActivityLock(Instant expiry) {
+        CodeSyncLock pricingAlertLock = new CodeSyncLock(Constants.LockFileType.PROJECT_LOCK, TEAM_ACTIVITY_ALERT_LOCK_KEY);
+        pricingAlertLock.acquireLock(TEAM_ACTIVITY_ALERT_LOCK_KEY, expiry);
+    }
+
+    /*
+        Return an Instant for 4:30 PM for tomorrow (tomorrow here means 1 day in the future of the time when this function is called.)
+        Instant would be in the local time zone.
+    */
+    private static Instant getTomorrowAlertInstant() {
+        ZoneId timeZone = ZoneId.systemDefault();
+        LocalDateTime reminderDateTime = LocalDateTime.now(timeZone)
+            .withHour(16)
+            .withMinute(30)
+            .withSecond(0)
+            .plusDays(1);
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(reminderDateTime, timeZone);
+        return zonedDateTime.toInstant();
+    }
+    private static boolean hasActivityInTheLastDay(JSONObject jsonResponse) {
+        ZoneId timeZone = ZoneId.systemDefault();
+        LocalDateTime yesterdayDateTime = LocalDateTime.now(timeZone)
+            .withHour(16)
+            .withMinute(30)
+            .withSecond(0)
+            .minusDays(1);
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(yesterdayDateTime, timeZone);
+        ZonedDateTime now = ZonedDateTime.now(timeZone);
+
+        Instant yesterday = zonedDateTime.toInstant();
+
+        return DataUtils.hasActivity(jsonResponse, yesterday, now.toInstant());
+    }
+
+    /*
+    Return `true` if user should be shown a team activity alert, `false` otherwise.
+    */
+    public static boolean canShowTeamActivityAlert() {
+        CodeSyncLock pricingAlertLock = new CodeSyncLock(Constants.LockFileType.PROJECT_LOCK, TEAM_ACTIVITY_ALERT_LOCK_KEY);
+
+        // If lock is acquired, then we should not show team activity alert.
+        // We would only show alerts once the lock expires.
+        return !pricingAlertLock.isLockAcquired(TEAM_ACTIVITY_ALERT_LOCK_KEY);
+    }
+
+    /*
+        Update the lock to remind the user 15 minutes later.
+    */
+    public static void remindLater() {
+        Instant fifteenMinutesInFuture = Instant.now().plus(15, ChronoUnit.MINUTES);
+        acquireTeamActivityLock(fifteenMinutesInFuture);
+    }
+
+    /*
+    Update the lock to skip the reminder for today and remind the user tomorrow.
+     */
+    public static void skipToday() {
+        Instant reminderInstant = getTomorrowAlertInstant();
+        acquireTeamActivityLock(reminderInstant);
+    }
+
+    public static void showTeamActivityAlert(Project project) {
+        if (!canShowTeamActivityAlert()) {
+            return;
+        }
+
+        String accessToken = UserFile.getAccessToken();
+        CodeSyncClient codeSyncClient = new CodeSyncClient();
+        JSONObject jsonResponse = codeSyncClient.getTeamActivity(accessToken);
+        if (hasActivityInTheLastDay(jsonResponse)) {
+            TeamActivityAlertDialog teamActivityAlertDialog = new TeamActivityAlertDialog(WEBAPP_DASHBOARD_URL, project);
+            teamActivityAlertDialog.show();
+        }
+    }
+}

--- a/src/main/java/org/intellij/sdk/codesync/auth/AuthAction.java
+++ b/src/main/java/org/intellij/sdk/codesync/auth/AuthAction.java
@@ -45,7 +45,7 @@ public class AuthAction extends AnAction {
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Project project = e.getProject();
-        if(project == null) {
+        if (project == null) {
             NotificationManager.notifyError("An error occurred trying to perform authentication action.");
             CodeSyncLogger.warning("An error occurred trying to perform authentication action. e.getProject() is null.");
 

--- a/src/main/java/org/intellij/sdk/codesync/auth/AuthAction.java
+++ b/src/main/java/org/intellij/sdk/codesync/auth/AuthAction.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.project.Project;
 import org.intellij.sdk.codesync.CodeSyncLogger;
 import org.intellij.sdk.codesync.NotificationManager;
 import org.intellij.sdk.codesync.commands.ClearReposToIgnoreCache;
@@ -22,6 +23,12 @@ import static org.intellij.sdk.codesync.Constants.*;
 public class AuthAction extends AnAction {
     @Override
     public void update(@NotNull AnActionEvent e) {
+        Project project = e.getProject();
+        if (project ==  null) {
+            e.getPresentation().setEnabled(false);
+            return;
+        }
+
         PluginState pluginState = StateUtils.getGlobalState();
         Presentation presentation = e.getPresentation();
         if (pluginState.isAuthenticated) {
@@ -37,6 +44,14 @@ public class AuthAction extends AnAction {
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
+        Project project = e.getProject();
+        if(project == null) {
+            NotificationManager.notifyError("An error occurred trying to perform authentication action.");
+            CodeSyncLogger.warning("An error occurred trying to perform authentication action. e.getProject() is null.");
+
+            return;
+        }
+
         PluginState pluginState = StateUtils.getGlobalState();
 
         CodeSyncAuthServer server;
@@ -49,7 +64,7 @@ public class AuthAction extends AnAction {
                     userFile = new UserFile(USER_FILE_PATH);
                 } catch (FileNotFoundException error) {
                     NotificationManager.notifyError(
-                            "An error occurred trying to logout the user, please tyr again later.", e.getProject()
+                            "An error occurred trying to logout the user, please tyr again later.", project
                     );
                     CodeSyncLogger.error(
                             String.format("[INTELLIJ_AUTH_ERROR]: auth file not found. Error: %s", error.getMessage())
@@ -58,7 +73,7 @@ public class AuthAction extends AnAction {
                 } catch (InvalidYmlFileError error) {
                     error.printStackTrace();
                     NotificationManager.notifyError(
-                            "An error occurred trying to logout the user, please tyr again later.", e.getProject()
+                            "An error occurred trying to logout the user, please tyr again later.", project
                     );
                     CodeSyncLogger.critical(
                             String.format("[INTELLIJ_AUTH_ERROR]: Invalid auth file. Error: %s", error.getMessage()),
@@ -75,7 +90,7 @@ public class AuthAction extends AnAction {
                     userFile.writeYml();
                 } catch (FileNotFoundException | InvalidYmlFileError error) {
                     NotificationManager.notifyError(
-                            "An error occurred trying to logout the user, please tyr again later.", e.getProject()
+                            "An error occurred trying to logout the user, please tyr again later.", project
                     );
                     CodeSyncLogger.error(
                             String.format("[INTELLIJ_AUTH_ERROR]: Could write to auth file. Error: %s", error.getMessage())
@@ -83,17 +98,17 @@ public class AuthAction extends AnAction {
                     return;
                 }
                 // Reload the state now.
-                StateUtils.reloadState(e.getProject());
+                StateUtils.reloadState(project);
 
                 NotificationManager.notifyInformation(
-                        "You have been logged out successfully.", e.getProject()
+                        "You have been logged out successfully.", project
                 );
             } else {
                 CodeSyncLogger.debug(
                         "[INTELLIJ_AUTH]: User initiated login flow."
                 );
                 BrowserUtil.browse(targetURL);
-                CodeSyncAuthServer.registerPostAuthCommand(new ReloadStateCommand(e.getProject()));
+                CodeSyncAuthServer.registerPostAuthCommand(new ReloadStateCommand(project));
             }
 
         } catch (Exception exc) {

--- a/src/main/java/org/intellij/sdk/codesync/clients/ClientUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/clients/ClientUtils.java
@@ -1,5 +1,6 @@
 package org.intellij.sdk.codesync.clients;
 
+import io.netty.channel.ConnectTimeoutException;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -14,6 +15,7 @@ import org.json.simple.JSONObject;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.SocketTimeoutException;
 
 
 public class ClientUtils {
@@ -86,11 +88,13 @@ public class ClientUtils {
 
     public static JSONResponse sendGet(String url, String accessToken) throws RequestError, InvalidJsonError {
         try (CloseableHttpClient httpClient = getHttpClientBuilder().build()) {
-            // Build HTTP POST request instance.
+            // Build HTTP GET request instance.
             HttpGet httpGet = getHttpGet(url, accessToken);
 
             try (CloseableHttpResponse httpResponse = httpClient.execute(httpGet)) {
                 return JSONResponse.from(httpResponse);
+            } catch (SocketTimeoutException | ConnectTimeoutException error) {
+                throw new RequestError("Request to CodeSync server timed out.");
             } catch (IOException error) {
                 throw new RequestError("Could not make a successful request to CodeSync server.");
             }
@@ -112,6 +116,8 @@ public class ClientUtils {
 
             try (CloseableHttpResponse httpResponse = httpClient.execute(httpPost)) {
                 return JSONResponse.from(httpResponse);
+            } catch (SocketTimeoutException | ConnectTimeoutException error) {
+                throw new RequestError("Request to CodeSync server timed out.");
             } catch (IOException error) {
                 throw new RequestError("Could not make a successful request to CodeSync server.");
             }
@@ -128,11 +134,13 @@ public class ClientUtils {
 
     public static JSONResponse sendPatch(String url, JSONObject payload, String accessToken) throws RequestError, InvalidJsonError {
         try (CloseableHttpClient httpClient = getHttpClientBuilder().build()) {
-            // Build HTTP POST request instance.
+            // Build HTTP PATCH request instance.
             HttpPatch httpPatch = getHttpPatch(url, payload, accessToken);
 
             try (CloseableHttpResponse httpResponse = httpClient.execute(httpPatch)) {
                 return JSONResponse.from(httpResponse);
+            } catch (SocketTimeoutException | ConnectTimeoutException error) {
+                throw new RequestError("Request to CodeSync server timed out.");
             } catch (IOException error) {
                 throw new RequestError("Could not make a successful request to CodeSync server.");
             }

--- a/src/main/java/org/intellij/sdk/codesync/clients/CodeSyncClient.java
+++ b/src/main/java/org/intellij/sdk/codesync/clients/CodeSyncClient.java
@@ -266,4 +266,15 @@ public class CodeSyncClient {
             return null;
         }
     }
+
+    public JSONObject getTeamActivity(String accessToken) {
+        try {
+            JSONResponse jsonResponse = ClientUtils.sendGet(TEAM_ACTIVITY_ENDPOINT, accessToken);
+            jsonResponse.raiseForStatus();
+            return jsonResponse.getJsonResponse();
+        } catch (RequestError | InvalidJsonError | StatusCodeError error) {
+            CodeSyncLogger.error(String.format("Error while getting team activity data. %s", error.getMessage()));
+            return null;
+        }
+    }
 }

--- a/src/main/java/org/intellij/sdk/codesync/clients/CodeSyncClient.java
+++ b/src/main/java/org/intellij/sdk/codesync/clients/CodeSyncClient.java
@@ -2,7 +2,6 @@ package org.intellij.sdk.codesync.clients;
 
 import kotlin.Pair;
 
-import org.apache.http.client.methods.HttpGet;
 import org.intellij.sdk.codesync.CodeSyncLogger;
 import org.intellij.sdk.codesync.exceptions.*;
 import org.intellij.sdk.codesync.exceptions.response.StatusCodeError;
@@ -11,15 +10,12 @@ import org.intellij.sdk.codesync.files.DiffFile;
 import static org.intellij.sdk.codesync.Constants.*;
 import org.intellij.sdk.codesync.models.User;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.intellij.sdk.codesync.models.UserPlan;
 import org.intellij.sdk.codesync.state.PluginState;
 import org.intellij.sdk.codesync.state.StateUtils;
 import org.intellij.sdk.codesync.utils.CommonUtils;
 import org.intellij.sdk.codesync.utils.FileUtils;
-import org.intellij.sdk.codesync.utils.PricingAlerts;
+import org.intellij.sdk.codesync.alerts.PricingAlerts;
 import org.json.simple.JSONObject;
 
 import java.io.File;
@@ -38,12 +34,10 @@ public class CodeSyncClient {
     }
 
     public Boolean isServerUp() {
-        HttpClient httpClient = HttpClientBuilder.create().build();
-        HttpGet healthCheck = new HttpGet(API_HEALTHCHECK);
         try {
-            HttpResponse response = httpClient.execute(healthCheck);
-            return response.getStatusLine().getStatusCode() == 200;
-        } catch (IOException e) {
+            JSONResponse jsonResponse = ClientUtils.sendGet(API_HEALTHCHECK);
+            return jsonResponse.getStatusCode() == 200;
+        } catch (InvalidJsonError | RequestError error) {
             return false;
         }
     }

--- a/src/main/java/org/intellij/sdk/codesync/clients/CodeSyncWebSocketClient.java
+++ b/src/main/java/org/intellij/sdk/codesync/clients/CodeSyncWebSocketClient.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 
 import org.apache.http.client.utils.URIBuilder;
 import org.intellij.sdk.codesync.utils.CommonUtils;
-import org.intellij.sdk.codesync.utils.PricingAlerts;
+import org.intellij.sdk.codesync.alerts.PricingAlerts;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.json.simple.JSONArray;

--- a/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
+++ b/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
@@ -32,7 +32,7 @@ import org.intellij.sdk.codesync.repoManagers.OriginalsRepoManager;
 import org.intellij.sdk.codesync.repoManagers.ShadowRepoManager;
 import org.intellij.sdk.codesync.utils.CommonUtils;
 import org.intellij.sdk.codesync.utils.FileUtils;
-import org.intellij.sdk.codesync.utils.PricingAlerts;
+import org.intellij.sdk.codesync.alerts.PricingAlerts;
 import org.jetbrains.annotations.NotNull;
 import org.json.simple.JSONObject;
 

--- a/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
+++ b/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
@@ -144,11 +144,14 @@ public class CodeSyncSetup {
             if (configFile.isRepoDisconnected(repoPath) || !configRepo.isSuccessfullySyncedWithBranch()) {
                 String branchName = Utils.GetGitBranch(repoPath);
                 codeSyncProgressIndicator.setMileStone(InitRepoMilestones.CHECK_USER_ACCESS);
+                boolean hasAccessToken = checkUserAccess(project, repoPath, repoName, branchName, skipSyncPrompt, isSyncingBranch);
+                if (!hasAccessToken) {
+                    NotificationManager.notifyInformation(Notification.LOGIN_REQUIRED_FOR_SYNC_MESSAGE, project);
+                    return;
+                }
 
                 if (skipSyncPrompt) {
-                    if (checkUserAccess(project, repoPath, repoName, branchName)) {
-                        syncRepo(repoPath, repoName, branchName, project, codeSyncProgressIndicator, isSyncingBranch);
-                    }
+                    syncRepo(repoPath, repoName, branchName, project, codeSyncProgressIndicator, isSyncingBranch);
                     return;
                 }
 
@@ -167,10 +170,7 @@ public class CodeSyncSetup {
                     );
 
                     if (shouldSyncRepo) {
-                        boolean hasAccessToken = checkUserAccess(project, repoPath, repoName, branchName);
-                        if (hasAccessToken) {
-                            syncRepo(repoPath, repoName, branchName, project, codeSyncProgressIndicator, false);
-                        }
+                        syncRepo(repoPath, repoName, branchName, project, codeSyncProgressIndicator, false);
                     }
                 }
             } else if (!configFile.isRepoDisconnected(repoPath)) {
@@ -247,7 +247,7 @@ public class CodeSyncSetup {
 
     This will also trigger the authentication flow if user does not have access token setup.
      */
-    public static boolean checkUserAccess(Project project, String repoPath, String repoName, String branchName) {
+    public static boolean checkUserAccess(Project project, String repoPath, String repoName, String branchName, boolean skipSyncPrompt, boolean isSyncingBranch) {
         String accessToken;
         try {
             UserFile userFile = new UserFile(USER_FILE_PATH);
@@ -288,7 +288,7 @@ public class CodeSyncSetup {
         CodeSyncAuthServer server;
         try {
             server =  CodeSyncAuthServer.getInstance();
-            CodeSyncAuthServer.registerPostAuthCommand(new ResumeCodeSyncCommand(project, repoPath, repoName, branchName));
+            CodeSyncAuthServer.registerPostAuthCommand(new ResumeCodeSyncCommand(project, repoPath, repoName, skipSyncPrompt, isSyncingBranch));
             CodeSyncAuthServer.registerPostAuthCommand(new ReloadStateCommand(project));
             BrowserUtil.browse(server.getAuthorizationUrl());
 
@@ -303,32 +303,7 @@ public class CodeSyncSetup {
             NotificationManager.notifyError("There was a problem with login, please try again later.", project);
         }
 
-
         return false;
-    }
-
-    /*
-    Start an async task to sync repo.
-     */
-    public static void syncRepoAsync(Project project, String repoPath, String repoName, String branchName) {
-        if (CommonUtils.isWindows()){
-            // For some reason people at intelli-j thought it would be a good idea to confuse users by using
-            // forward slashes in paths instead of windows path separator.
-            repoPath = repoPath.replaceAll("/", "\\\\");
-        }
-
-        String finalRepoPath = repoPath;
-        ProgressManager.getInstance().run(new Task.Backgroundable(project, "Initializing repo"){
-            public void run(@NotNull ProgressIndicator progressIndicator) {
-                CodeSyncProgressIndicator codeSyncProgressIndicator = new CodeSyncProgressIndicator(progressIndicator);
-
-                // Set the progress bar percentage and text
-                codeSyncProgressIndicator.setMileStone(InitRepoMilestones.START);
-                syncRepo(finalRepoPath, repoName, branchName, project, codeSyncProgressIndicator, false);
-
-                // Finished
-                codeSyncProgressIndicator.setMileStone(InitRepoMilestones.END);
-            }});
     }
 
     public static void syncRepo(String repoPath, String repoName, String branchName, Project project, CodeSyncProgressIndicator codeSyncProgressIndicator, boolean isSyncingBranch) {
@@ -404,7 +379,6 @@ public class CodeSyncSetup {
         false otherwise.
     */
     public static boolean uploadRepo(String repoPath, String repoName, String[] filePaths, Project project, CodeSyncProgressIndicator codeSyncProgressIndicator, boolean isSyncingBranch) {
-
         // If plan limit is reached then do not process new repos.
         if (PricingAlerts.getPlanLimitReached()) {
             return false;

--- a/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetupAction.java
+++ b/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetupAction.java
@@ -12,6 +12,7 @@ import org.intellij.sdk.codesync.exceptions.base.BaseException;
 import org.intellij.sdk.codesync.exceptions.base.BaseNetworkException;
 import org.intellij.sdk.codesync.exceptions.common.FileNotInModuleError;
 import org.intellij.sdk.codesync.utils.FileUtils;
+import org.intellij.sdk.codesync.utils.PricingAlerts;
 import org.intellij.sdk.codesync.utils.ProjectUtils;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetupAction.java
+++ b/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetupAction.java
@@ -12,7 +12,6 @@ import org.intellij.sdk.codesync.exceptions.base.BaseException;
 import org.intellij.sdk.codesync.exceptions.base.BaseNetworkException;
 import org.intellij.sdk.codesync.exceptions.common.FileNotInModuleError;
 import org.intellij.sdk.codesync.utils.FileUtils;
-import org.intellij.sdk.codesync.utils.PricingAlerts;
 import org.intellij.sdk.codesync.utils.ProjectUtils;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetupAction.java
+++ b/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetupAction.java
@@ -26,14 +26,15 @@ public class CodeSyncSetupAction extends BaseModuleAction {
         Project project = e.getProject();
         if (project ==  null) {
             e.getPresentation().setEnabled(false);
+            return;
         }
-        VirtualFile[] contentRoots = ProjectUtils.getAllContentRoots(e.getProject());
+        VirtualFile[] contentRoots = ProjectUtils.getAllContentRoots(project);
         if (contentRoots.length > 1) {
             // If more than one module are present in the project then a file must be open to show repo setup action
             // this is needed because without the file we can not determine the correct repo sync.
             try {
                 VirtualFile virtualFile = e.getRequiredData(CommonDataKeys.PSI_FILE).getVirtualFile();
-                if (this.isRepoInSync(virtualFile, e.getProject())) {
+                if (this.isRepoInSync(virtualFile, project)) {
                     Presentation presentation = e.getPresentation();
                     presentation.setText("Disconnect Repo...");
                     presentation.setDescription("Disconnect repo...");
@@ -66,9 +67,16 @@ public class CodeSyncSetupAction extends BaseModuleAction {
     public void actionPerformed(@NotNull AnActionEvent e) {
         Project project = e.getProject();
 
+        if(project == null) {
+            NotificationManager.notifyError("An error occurred trying to perform repo playback action.");
+            CodeSyncLogger.error("An error occurred trying to perform repo playback action. e.getProject() is null.");
+
+            return;
+        }
+
         // Check if any of the modules inside this project are synced with codesync or not.
         // We will show repo playback button if even a single repo is synced.
-        VirtualFile[] contentRoots = ProjectUtils.getAllContentRoots(e.getProject());
+        VirtualFile[] contentRoots = ProjectUtils.getAllContentRoots(project);
         if (contentRoots.length > 1) {
             // If more than one module are present in the project then a file must be open to show repo setup action
             // this is needed because without the file we can not determine the correct repo sync.
@@ -77,7 +85,7 @@ public class CodeSyncSetupAction extends BaseModuleAction {
                 String repoPath = ProjectUtils.getRepoPath(virtualFile, project);
                 String repoName = ProjectUtils.getRepoName(virtualFile, project);
 
-                if (this.isRepoInSync(virtualFile, e.getProject())) {
+                if (this.isRepoInSync(virtualFile, project)) {
                     try {
                         CodeSyncSetup.disconnectRepo(project, repoPath, repoName);
                     } catch (BaseException | BaseNetworkException error) {

--- a/src/main/java/org/intellij/sdk/codesync/files/DiffFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/DiffFile.java
@@ -18,7 +18,7 @@ import static org.intellij.sdk.codesync.Constants.DIFF_SIZE_LIMIT;
 
 public class DiffFile {
     public String diff, branch, fileRelativePath, repoPath, newRelativePath, oldRelativePath, newPath, oldPath, newAbsolutePath, oldAbsolutePath;
-    public Date createdAt;
+    public Date createdAt, addedAt; // `addedAt` means the date file sync started. Only useful in case of new file diff.
     public Boolean isBinary, isDeleted, isNewFile, isRename, isDirRename;
     public File originalDiffFile;
 
@@ -47,6 +47,10 @@ public class DiffFile {
         this.isNewFile = CommonUtils.getBoolValue(obj, "is_new_file", false);
         this.isRename = CommonUtils.getBoolValue(obj, "is_rename", false);
         this.isDirRename = CommonUtils.getBoolValue(obj, "is_dir_rename", false);
+
+        if (this.isNewFile) {
+            this.addedAt =  CommonUtils.parseDate((String) obj.get("added_at"));
+        }
 
         if (this.isDirRename) {
             try {

--- a/src/main/java/org/intellij/sdk/codesync/locks/CodeSyncLock.java
+++ b/src/main/java/org/intellij/sdk/codesync/locks/CodeSyncLock.java
@@ -47,6 +47,9 @@ public class CodeSyncLock {
         }
     }
 
+    /*
+    Acquire lock and return `true` if lock was acquired with success or `false` of lock could not be acquired.
+    */
     public boolean acquireLock(String identifier) {
         // Default expiry is 5 minutes.
         Instant defaultExpiry = Instant.now().plus(5, ChronoUnit.MINUTES);
@@ -63,6 +66,19 @@ public class CodeSyncLock {
             return false;
         } else {
             return this.lockFile.publishNewLock(this.lock.getCategory(), expiry, identifier);
+        }
+    }
+
+    /*
+    Return `true` if lock was acquired with success or `false` of lock could not be acquired.
+    */
+    public boolean isLockAcquired(String identifier) {
+        if (this.lock == null) {
+            return false;
+        } else {
+            // If lock is active and has the same identifier as the argument then lock is acquired,
+            // and we should return true.
+            return this.lock.isActive() && this.lock.compareIdentifier(identifier);
         }
     }
 

--- a/src/main/java/org/intellij/sdk/codesync/ui/dialogs/ActivityAlertDialog.java
+++ b/src/main/java/org/intellij/sdk/codesync/ui/dialogs/ActivityAlertDialog.java
@@ -5,7 +5,7 @@ import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import org.intellij.sdk.codesync.Constants.Notification;
-import org.intellij.sdk.codesync.alerts.TeamActivityAlerts;
+import org.intellij.sdk.codesync.alerts.ActivityAlerts;
 import org.intellij.sdk.codesync.utils.CommonUtils;
 import org.jdesktop.swingx.JXLabel;
 import org.jetbrains.annotations.NotNull;
@@ -16,24 +16,35 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 
 
-public class TeamActivityAlertDialog extends DialogWrapper {
-    String primaryMessage = Notification.TEAM_ACTIVITY_ALERT_MESSAGE,
-        secondaryMessage = Notification.TEAM_ACTIVITY_ALERT_SECONDARY_MESSAGE,
-        title = Notification.TEAM_ACTIVITY_ALERT_HEADER_MESSAGE,
-        reviewButtonText = "View team activity",
+public class ActivityAlertDialog extends DialogWrapper {
+    String primaryMessage, secondaryMessage, title, reviewButtonText,
         reviewLaterButtonText = "Remind me later",
         cancelButtonText = "Skip for today"
     ;
     String teamActivityURL;
 
-    public TeamActivityAlertDialog(String teamActivityURL, Project project){
+    public ActivityAlertDialog(String teamActivityURL, boolean isTeamActivity, Project project){
         super(project, true);
         this.teamActivityURL = teamActivityURL;
+
+        if (isTeamActivity) {
+            this.title = Notification.TEAM_ACTIVITY_ALERT_HEADER_MESSAGE;
+            this.primaryMessage = Notification.TEAM_ACTIVITY_ALERT_MESSAGE;
+            this.secondaryMessage = Notification.TEAM_ACTIVITY_ALERT_SECONDARY_MESSAGE;
+
+            this.reviewButtonText = "View team activity";
+        } else {
+            this.title = Notification.ACTIVITY_ALERT_HEADER_MESSAGE;
+            this.primaryMessage = Notification.ACTIVITY_ALERT_MESSAGE;
+            this.secondaryMessage = Notification.ACTIVITY_ALERT_SECONDARY_MESSAGE;
+            this.reviewButtonText = "View activity";
+        }
+
         setTitle(this.title);
     }
 
-    public TeamActivityAlertDialog(String teamActivityURL){
-        this(teamActivityURL, null);
+    public ActivityAlertDialog(String teamActivityURL, boolean isTeamActivity){
+        this(teamActivityURL, isTeamActivity, null);
     }
 
     public void show() {
@@ -67,13 +78,13 @@ public class TeamActivityAlertDialog extends DialogWrapper {
     protected void redirectToTeamActivity() {
         BrowserUtil.browse(this.teamActivityURL);
         // User has already been redirected to the activity page, we can now skip subsequent alerts.
-        TeamActivityAlerts.skipToday();
+        ActivityAlerts.skipToday();
     }
     protected void remindLaterAction() {
-        TeamActivityAlerts.remindLater();
+        ActivityAlerts.remindLater();
     }
     protected void skipForTodayAction() {
-        TeamActivityAlerts.skipToday();
+        ActivityAlerts.skipToday();
     }
 
     @Override

--- a/src/main/java/org/intellij/sdk/codesync/ui/dialogs/ActivityAlertDialog.java
+++ b/src/main/java/org/intellij/sdk/codesync/ui/dialogs/ActivityAlertDialog.java
@@ -14,6 +14,8 @@ import javax.annotation.Nullable;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
 
 public class ActivityAlertDialog extends DialogWrapper {
@@ -41,6 +43,14 @@ public class ActivityAlertDialog extends DialogWrapper {
         }
 
         setTitle(this.title);
+        getWindow().addWindowListener(
+            new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    remindLaterAction();
+                }
+            }
+        );
     }
 
     public ActivityAlertDialog(String teamActivityURL, boolean isTeamActivity){

--- a/src/main/java/org/intellij/sdk/codesync/ui/dialogs/PricingAlertDialog.java
+++ b/src/main/java/org/intellij/sdk/codesync/ui/dialogs/PricingAlertDialog.java
@@ -58,7 +58,7 @@ public class PricingAlertDialog extends DialogWrapper {
         JPanel dialogPanel = new JPanel(new BorderLayout());
 
         String htmlMessage = String.format(
-            "<html><p>%s</p><p>%s</p><br/></html>", this.primaryMessage, this.secondaryMessage
+            "<html><p>%s</p><br/><p>%s</p><br/></html>", this.primaryMessage, this.secondaryMessage
         );
         JXLabel label = new JXLabel(htmlMessage);
         label.setLineWrap(true);

--- a/src/main/java/org/intellij/sdk/codesync/ui/dialogs/TeamActivityAlertDialog.java
+++ b/src/main/java/org/intellij/sdk/codesync/ui/dialogs/TeamActivityAlertDialog.java
@@ -1,0 +1,112 @@
+package org.intellij.sdk.codesync.ui.dialogs;
+
+import com.intellij.ide.BrowserUtil;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import org.intellij.sdk.codesync.Constants.Notification;
+import org.intellij.sdk.codesync.alerts.TeamActivityAlerts;
+import org.intellij.sdk.codesync.utils.CommonUtils;
+import org.jdesktop.swingx.JXLabel;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+
+
+public class TeamActivityAlertDialog extends DialogWrapper {
+    String primaryMessage = Notification.TEAM_ACTIVITY_ALERT_MESSAGE,
+        secondaryMessage = Notification.TEAM_ACTIVITY_ALERT_SECONDARY_MESSAGE,
+        title = Notification.TEAM_ACTIVITY_ALERT_HEADER_MESSAGE,
+        reviewButtonText = "View team activity",
+        reviewLaterButtonText = "Remind me later",
+        cancelButtonText = "Skip for today"
+    ;
+    String teamActivityURL;
+
+    public TeamActivityAlertDialog(String teamActivityURL, Project project){
+        super(project, true);
+        this.teamActivityURL = teamActivityURL;
+        setTitle(this.title);
+    }
+
+    public TeamActivityAlertDialog(String teamActivityURL){
+        this(teamActivityURL, null);
+    }
+
+    public void show() {
+        CommonUtils.invokeAndWait(
+            () -> {
+                init();
+                super.show();
+                return OK_EXIT_CODE;
+            },
+            ModalityState.defaultModalityState()
+        );
+    }
+
+    @Nullable
+    @Override
+    protected JComponent createCenterPanel() {
+        JPanel dialogPanel = new JPanel(new BorderLayout());
+
+        String htmlMessage = String.format(
+            "<html><p>%s</p><br/><p>%s</p><br/></html>", this.primaryMessage, this.secondaryMessage
+        );
+        JXLabel label = new JXLabel(htmlMessage);
+        label.setMaxLineSpan(200);
+        label.setLineWrap(true);
+        label.setPreferredSize(new Dimension(500, Integer.MAX_VALUE));
+        dialogPanel.add(label, BorderLayout.LINE_START);
+
+        return dialogPanel;
+    }
+
+    protected void redirectToTeamActivity() {
+        BrowserUtil.browse(this.teamActivityURL);
+        // User has already been redirected to the activity page, we can now skip subsequent alerts.
+        TeamActivityAlerts.skipToday();
+    }
+    protected void remindLaterAction() {
+        TeamActivityAlerts.remindLater();
+    }
+    protected void skipForTodayAction() {
+        TeamActivityAlerts.skipToday();
+    }
+
+    @Override
+    protected Action @NotNull [] createActions() {
+        return new Action[]{
+            new AbstractAction(reviewButtonText) {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    if (isEnabled()) {
+                        redirectToTeamActivity();
+                        close(OK_EXIT_CODE);
+                    }
+                }
+            },
+            new AbstractAction(reviewLaterButtonText) {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    if (isEnabled()) {
+                        remindLaterAction();
+                        close(OK_EXIT_CODE);
+                    }
+                }
+            },
+            new AbstractAction(cancelButtonText) {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    if (isEnabled()) {
+                        skipForTodayAction();
+                        close(CANCEL_EXIT_CODE);
+                    }
+                }
+            },
+        };
+    }
+
+}

--- a/src/main/java/org/intellij/sdk/codesync/utils/CommonUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/utils/CommonUtils.java
@@ -174,10 +174,7 @@ public class CommonUtils {
     }
 
     public static String getCurrentDatetime()  {
-        Date currentTime = new Date();
-        SimpleDateFormat sdf = new SimpleDateFormat(DATE_TIME_FORMAT);
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return sdf.format(currentTime);
+        return formatDate(new Date());
     }
 
     public static Project getCurrentProject(String repoPath) {

--- a/src/main/java/org/intellij/sdk/codesync/utils/CommonUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/utils/CommonUtils.java
@@ -100,8 +100,8 @@ public class CommonUtils {
     }
 
     @Nullable
-    public static Date parseDate(String dateString) {
-        SimpleDateFormat pattern = new SimpleDateFormat(DATE_TIME_FORMAT);
+    public static Date parseDate(String dateString, String format) {
+        SimpleDateFormat pattern = new SimpleDateFormat(format);
         try {
             return new Date(pattern.parse(dateString).getTime());
         } catch (ParseException pe) {
@@ -109,17 +109,26 @@ public class CommonUtils {
         }
     }
 
+    @Nullable
+    public static Date parseDate(String dateString) {
+        return parseDate(dateString, DATE_TIME_FORMAT);
+    }
+
     /*
     Using instant because it handles time zone correctly.
      */
     @Nullable
-    public static Instant parseDateToInstant(String dateString) {
-        SimpleDateFormat pattern = new SimpleDateFormat(DATE_TIME_FORMAT);
-        try {
-            return new Date(pattern.parse(dateString).getTime()).toInstant();
-        } catch (ParseException pe) {
-            return null;
+    public static Instant parseDateToInstant(String dateString, String format) {
+        Date date = parseDate(dateString, format);
+        if (date != null) {
+            return date.toInstant();
         }
+        return null;
+    }
+
+    @Nullable
+    public static Instant parseDateToInstant(String dateString) {
+        return parseDateToInstant(dateString, DATE_TIME_FORMAT);
     }
 
     public static String formatDate(Instant instant) {

--- a/src/main/java/org/intellij/sdk/codesync/utils/DataUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/utils/DataUtils.java
@@ -1,0 +1,36 @@
+package org.intellij.sdk.codesync.utils;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+import java.time.Instant;
+
+import static org.intellij.sdk.codesync.Constants.DATE_TIME_FORMAT_WITHOUT_TIMEZONE;
+
+/*
+Utility class for handling operations on the data, usually the response from CodeSync REST API.
+ */
+public class DataUtils {
+    /*
+    Check if there is any team activity during the specified time period.
+     */
+    public static boolean hasActivity(JSONObject activityResponse, Instant from, Instant to) {
+        if (!activityResponse.containsKey("activities")) {
+            // No activity
+            return false;
+        }
+        JSONArray activities = (JSONArray) activityResponse.get("activities");
+        return activities
+            .stream()
+            .anyMatch(
+                activity -> {
+                    Instant lastSyncedAt = CommonUtils.parseDateToInstant(
+                        (String) ((JSONObject) activity).get("last_synced_at"),
+                        DATE_TIME_FORMAT_WITHOUT_TIMEZONE
+                    );
+                    return lastSyncedAt != null && (lastSyncedAt.isAfter(from) && lastSyncedAt.isBefore(to));
+                }
+            );
+
+    }
+}

--- a/src/main/java/org/intellij/sdk/codesync/utils/DiffUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/utils/DiffUtils.java
@@ -41,6 +41,7 @@ public class DiffUtils {
         }
         if (isNewFile) {
             data.put("is_new_file", true);
+            data.put("added_at", CommonUtils.getCurrentDatetime());
         }
         if (isDeleted) {
             data.put("is_deleted", true);


### PR DESCRIPTION
__Description:__
Here is a list of changes included in this PR.

- Show login prompt before repo-sync prompt.
- Added handling and guards agains null values of Project instance in different places inside the code base. This will help avoid null pointer exceptions.
- Explicitly set API timeout to 120 seconds for requests, also refactored client related code to add better error handling and make it cleaner.
- Included `added_at` parameter for new files so that correct time is used if user creates a file during the time period when user's plan has expired.
- Added a new dialog for showing user the prompt to review team activity.
- Added a new daemon to show alerts at 4:30 PM each day.
- Here is a screenshot of the new alert dialog
<img width="660" alt="Screenshot 2023-01-02 at 2 04 28 PM" src="https://user-images.githubusercontent.com/7114956/210212259-e8030a79-4ebe-471f-91c6-9b4f8ceab700.png">

