### PR TITLE
fix: Fixed a quick bug observed by new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.18.2] - 2022-01-20
+- Fixed a quick bug observed by new users.
+
 ## [3.18.1] - 2022-01-15
 - Bug fixes related to daemon processes and yml files.
 - Refactored and improved locking logic to handle edge cases.

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.codesync'
-version '3.18.1'
+version '3.18.2'
 
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"

--- a/src/main/java/org/intellij/sdk/codesync/ProjectOpenCloseListener.java
+++ b/src/main/java/org/intellij/sdk/codesync/ProjectOpenCloseListener.java
@@ -56,6 +56,8 @@ public class ProjectOpenCloseListener implements ProjectManagerListener {
     if (ApplicationManager.getApplication().isUnitTestMode()) {
       return;
     }
+    // Create system directories required by the plugin.
+    createSystemDirectories();
 
     CodeSyncLock codeSyncProjectLock = new CodeSyncLock(LockFileType.PROJECT_LOCK, project.getBasePath());
 
@@ -71,9 +73,6 @@ public class ProjectOpenCloseListener implements ProjectManagerListener {
     // Keep a very low expiry to make sure, if user switches between projects then lock does not cause issues.
     Instant expiry = Instant.now().plus(5, ChronoUnit.SECONDS);
     codeSyncProjectLock.acquireLock(project.getName(), expiry);
-
-    // Create system directories required by the plugin.
-    createSystemDirectories();
 
     // Populate state
     StateUtils.populateState(project);


### PR DESCRIPTION

__Testing Instructions:__
1. User should be able to open a project after installing codesync plugin for the very first time. (i.e. when `~/.codesync`) directory does not exist.
