### PR TITLE
Windows Fixes and Small Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.18.3] - 2022-01-26
+- Fixed file path issue for lock files.
+- Updates for the daemon calling functionality.
+- Fixed a path issue in the project lock file for Windows OS.
+- Updated logic for alerts to handle an edge case.
+- If previous alert was shown before 4 PM then we need to show another one at 4:30 PM
+
 ## [3.18.2] - 2022-01-20
 - Fixed a quick bug observed by new users.
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.codesync'
-version '3.18.2'
+version '3.18.3'
 
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"

--- a/src/main/java/org/intellij/sdk/codesync/Constants.java
+++ b/src/main/java/org/intellij/sdk/codesync/Constants.java
@@ -41,7 +41,7 @@ public final class Constants {
     public static final String[] IGNORABLE_DIRECTORIES = new String[]{".git", "node_modules", ".DS_Store", ".idea"};
     public static final String CURRENT_GIT_BRANCH_COMMAND = "git rev-parse --abbrev-ref HEAD";
     public static final Integer DELAY_BETWEEN_BUFFER_TASKS = 5000;
-    public static final Integer DELAY_BETWEEN_BUFFER_TASKS_IN_SECONDS = 6;
+    public static final Integer DELAY_BETWEEN_BUFFER_TASKS_IN_SECONDS = 5;
 
     public static final String DEFAULT_TIMEZONE = ZoneId.systemDefault().getId();
     public static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS z";

--- a/src/main/java/org/intellij/sdk/codesync/Constants.java
+++ b/src/main/java/org/intellij/sdk/codesync/Constants.java
@@ -45,6 +45,7 @@ public final class Constants {
 
     public static final String DEFAULT_TIMEZONE = ZoneId.systemDefault().getId();
     public static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS z";
+    public static final String ISO_DATE_TIME_FORMAT = "YYYY-MM-DDTHH:mm:ss.sssZ";
     public static final String DATE_FORMAT = "yyyy-MM-dd";
     public static final String DATE_TIME_FORMAT_WITHOUT_TIMEZONE = "yyyy-MM-dd HH:mm:ss.SSS";
     public static final String IDE_NAME = ApplicationInfo.getInstance().getVersionName();

--- a/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
@@ -6,7 +6,6 @@ import org.intellij.sdk.codesync.clients.CodeSyncClient;
 import org.intellij.sdk.codesync.clients.CodeSyncWebSocketClient;
 import org.intellij.sdk.codesync.exceptions.*;
 import org.intellij.sdk.codesync.files.*;
-import org.intellij.sdk.codesync.locks.CodeSyncLock;
 import org.intellij.sdk.codesync.repoManagers.DeletedRepoManager;
 import org.intellij.sdk.codesync.repoManagers.OriginalsRepoManager;
 import org.intellij.sdk.codesync.repoManagers.ShadowRepoManager;
@@ -120,16 +119,17 @@ public class HandleBuffer {
     Schedule buffer handler, a new daemon will be registered if there is none already running.
     */
     public static void scheduleBufferHandler(Project project) {
-        boolean canStartDaemon = ProjectUtils.canStartDaemon(
-            LockFileType.HANDLE_BUFFER_LOCK,
-            DIFFS_DAEMON_LOCK_KEY,
-            project.getName()
-        );
-
-        if (canStartDaemon) {
-            // Start the daemon.
-            ProjectUtils.startDaemonProcess(HandleBuffer::handleBuffer);
-        }
+        ProjectUtils.startDaemonProcess(() -> {
+            boolean canRunDaemon = ProjectUtils.canRunDaemon(
+                LockFileType.HANDLE_BUFFER_LOCK,
+                DIFFS_DAEMON_LOCK_KEY,
+                project.getName()
+            );
+            if (canRunDaemon) {
+                System.out.println("Calling handleBuffer.");
+                HandleBuffer.handleBuffer();
+            }
+        });
     }
 
     public static void handleBuffer() {

--- a/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
@@ -126,7 +126,6 @@ public class HandleBuffer {
                 project.getName()
             );
             if (canRunDaemon) {
-                System.out.printf("[%s]: Calling handleBuffer.%n", new Date());
                 HandleBuffer.handleBuffer();
             }
         });

--- a/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
@@ -126,7 +126,7 @@ public class HandleBuffer {
                 project.getName()
             );
             if (canRunDaemon) {
-                System.out.println("Calling handleBuffer.");
+                System.out.printf("[%s]: Calling handleBuffer.%n", new Date());
                 HandleBuffer.handleBuffer();
             }
         });

--- a/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
@@ -12,7 +12,6 @@ import org.intellij.sdk.codesync.files.ConfigFile;
 import org.intellij.sdk.codesync.files.ConfigRepo;
 import org.intellij.sdk.codesync.files.ConfigRepoBranch;
 import org.intellij.sdk.codesync.files.UserFile;
-import org.intellij.sdk.codesync.locks.CodeSyncLock;
 import org.intellij.sdk.codesync.repoManagers.DeletedRepoManager;
 import org.intellij.sdk.codesync.repoManagers.OriginalsRepoManager;
 import org.intellij.sdk.codesync.repoManagers.ShadowRepoManager;
@@ -125,16 +124,19 @@ public class PopulateBuffer {
     Schedule populate buffer daemon, a new daemon will be registered if there is none already running.
     */
     public static void startPopulateBufferDaemon(Project project) {
-        boolean canStartDaemon = ProjectUtils.canStartDaemon(
-            LockFileType.POPULATE_BUFFER_LOCK,
-            POPULATE_BUFFER_DAEMON_LOCK_KEY,
-            project.getName()
-        );
+        ProjectUtils.startDaemonProcess(() -> {
+            boolean canRunDaemon = ProjectUtils.canRunDaemon(
+                LockFileType.POPULATE_BUFFER_LOCK,
+                POPULATE_BUFFER_DAEMON_LOCK_KEY,
+                project.getName()
+            );
 
-        if (canStartDaemon) {
-            // Start the daemon.
-            ProjectUtils.startDaemonProcess(PopulateBuffer::populateBuffer);
-        }
+            if (canRunDaemon) {
+                // Start the daemon.
+                System.out.println("Calling populateBuffer.");
+                PopulateBuffer.populateBuffer();
+            }
+        });
     }
 
     public static void populateBuffer() {

--- a/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
@@ -133,7 +133,6 @@ public class PopulateBuffer {
 
             if (canRunDaemon) {
                 // Start the daemon.
-                System.out.printf("[%s]: Calling populateBuffer.%n", new Date());
                 PopulateBuffer.populateBuffer();
             }
         });

--- a/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
@@ -133,7 +133,7 @@ public class PopulateBuffer {
 
             if (canRunDaemon) {
                 // Start the daemon.
-                System.out.println("Calling populateBuffer.");
+                System.out.printf("[%s]: Calling populateBuffer.%n", new Date());
                 PopulateBuffer.populateBuffer();
             }
         });

--- a/src/main/java/org/intellij/sdk/codesync/ProjectOpenCloseListener.java
+++ b/src/main/java/org/intellij/sdk/codesync/ProjectOpenCloseListener.java
@@ -59,7 +59,7 @@ public class ProjectOpenCloseListener implements ProjectManagerListener {
     // Create system directories required by the plugin.
     createSystemDirectories();
 
-    CodeSyncLock codeSyncProjectLock = new CodeSyncLock(LockFileType.PROJECT_LOCK, project.getBasePath());
+    CodeSyncLock codeSyncProjectLock = new CodeSyncLock(LockFileType.PROJECT_LOCK, ProjectUtils.getRepoPath(project));
 
     // This code is executed multiple times when a project window is opened,
     // causing the callbacks to be registered many times, this lock would prevent the

--- a/src/main/java/org/intellij/sdk/codesync/ProjectOpenCloseListener.java
+++ b/src/main/java/org/intellij/sdk/codesync/ProjectOpenCloseListener.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.newvfs.BulkFileListener;
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
 import com.intellij.serviceContainer.AlreadyDisposedException;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.intellij.sdk.codesync.alerts.ActivityAlerts;
 import org.intellij.sdk.codesync.codeSyncSetup.CodeSyncSetup;
 import org.intellij.sdk.codesync.exceptions.common.FileNotInModuleError;
@@ -58,8 +59,12 @@ public class ProjectOpenCloseListener implements ProjectManagerListener {
     }
     // Create system directories required by the plugin.
     createSystemDirectories();
-
-    CodeSyncLock codeSyncProjectLock = new CodeSyncLock(LockFileType.PROJECT_LOCK, ProjectUtils.getRepoPath(project));
+    String repoDirPath = ProjectUtils.getRepoPath(project);
+    CodeSyncLock codeSyncProjectLock = new CodeSyncLock(
+        LockFileType.PROJECT_LOCK,
+        // We are using one way hash here to avoid special character (e.g. : in path) issues on some Operating Systems
+        repoDirPath != null ? DigestUtils.sha256Hex(repoDirPath): null
+    );
 
     // This code is executed multiple times when a project window is opened,
     // causing the callbacks to be registered many times, this lock would prevent the

--- a/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
+++ b/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
@@ -58,7 +58,14 @@ public class ActivityAlerts {
     Update the lock to skip the reminder for today and remind the user tomorrow.
      */
     public static void skipToday() {
+        Instant now = CommonUtils.getTodayInstant();
         Instant reminderInstant = CommonUtils.getTomorrowAlertInstant();
+
+        // if activity is shown before 4 AM then it was for yesterday's activity,
+        // and we need to show another notification after 4:30 PM today.
+        if (now.atZone(ZoneId.systemDefault()).getHour() < 4) {
+            reminderInstant = CommonUtils.getTodayInstant(16, 30, 0);
+        }
         acquireActivityLock(reminderInstant);
     }
 

--- a/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
+++ b/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
@@ -15,7 +15,6 @@ import org.json.simple.JSONObject;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 
 import static org.intellij.sdk.codesync.Constants.*;
 
@@ -62,8 +61,8 @@ public class ActivityAlerts {
         Instant reminderInstant = CommonUtils.getTomorrowAlertInstant();
 
         // if activity is shown before 4 PM then it was for yesterday's activity,
-        // and we need to show another notification after 4:30 PM today only if there has been an activity in past 24 h.
-        if (now.atZone(ZoneId.systemDefault()).getHour() < 4) {
+        // and we need to show another notification after 4:30 PM today only if there has been an activity in past 24h.
+        if (now.atZone(ZoneId.systemDefault()).getHour() < 16) {
             reminderInstant = CommonUtils.getTodayInstant(16, 30, 0);
         }
         acquireActivityLock(reminderInstant);

--- a/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
+++ b/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
@@ -93,7 +93,7 @@ public class ActivityAlerts {
             return;
         }
 
-        if (hasActivityInTheLastDay(jsonResponse)) {
+        if (!hasActivityInTheLastDay(jsonResponse)) {
             boolean isTeamActivity = jsonResponse.containsKey("is_team_activity") &&
                 (boolean) jsonResponse.get("is_team_activity");
 

--- a/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
+++ b/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
@@ -15,6 +15,7 @@ import org.json.simple.JSONObject;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
@@ -85,11 +86,21 @@ public class ActivityAlerts {
                 WEBAPP_DASHBOARD_URL, isTeamActivity, project
             );
             boolean hasUserChecked = activityAlertDialog.showAndGet();
+            Instant checkedFor;
+            Instant now = CommonUtils.getTodayInstant();
+
+            // if activity is shown before 4 AM then it was for yesterday's activity,
+            // and we need to show another notification after 4:30 PM today.
+            if (now.atZone(ZoneId.systemDefault()).getHour() < 4) {
+                checkedFor = CommonUtils.getYesterdayInstant();
+            } else {
+                checkedFor = CommonUtils.getTodayInstant();
+            }
             if (email != null && hasUserChecked) {
                 AlertsFile.updateTeamActivity(
                     email,
                     CommonUtils.getTodayInstant(),
-                    CommonUtils.getYesterdayInstant(),
+                    checkedFor,
                     CommonUtils.getTodayInstant()
                 );
             }

--- a/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
+++ b/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
@@ -16,7 +16,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 
 import static org.intellij.sdk.codesync.Constants.*;
 
@@ -97,18 +96,21 @@ public class ActivityAlerts {
     }
 
     /*
-    Schedule activity alert daemon, a new daemon will be registered if there is none already running.
+    Schedule activity alert daemon, daemon will make sure to run only once every 5 seconds.
     */
     public static void startActivityAlertDaemon(Project project) {
-        boolean canStartDaemon = ProjectUtils.canStartDaemon(
-            LockFileType.PROJECT_LOCK,
-            ACTIVITY_ALERT_DAEMON_LOCK_KEY,
-            project.getName()
-        );
+        ProjectUtils.startDaemonProcess(() -> {
+            boolean canRunDaemon = ProjectUtils.canRunDaemon(
+                LockFileType.PROJECT_LOCK,
+                ACTIVITY_ALERT_DAEMON_LOCK_KEY,
+                project.getName()
+            );
 
-        if (canStartDaemon) {
-            // Start the daemon.
-            ProjectUtils.startDaemonProcess(() -> showActivityAlert(project));
-        }
+            if (canRunDaemon) {
+                // Start the daemon.
+                System.out.println("Calling showActivityAlert.");
+                ProjectUtils.startDaemonProcess(() -> showActivityAlert(project));
+            }
+        });
     }
 }

--- a/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
+++ b/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
@@ -14,8 +14,6 @@ import org.json.simple.JSONObject;
 
 import java.time.Instant;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
@@ -27,12 +25,14 @@ public class ActivityAlerts {
         activityAlertLock.acquireLock(expiry);
     }
 
+    /*
+    Checks if user has had any activity from 4:30 PM yesterday to 4:30 PM today.
+    */
     private static boolean hasActivityInTheLastDay(JSONObject jsonResponse) {
-        ZoneId timeZone = ZoneId.systemDefault();
-        ZonedDateTime now = ZonedDateTime.now(timeZone);
+        Instant today = CommonUtils.getTodayInstant(16, 30, 0);
         Instant yesterday = CommonUtils.getYesterdayInstant();
 
-        return DataUtils.hasActivity(jsonResponse, yesterday, now.toInstant());
+        return DataUtils.hasActivity(jsonResponse, yesterday, today);
     }
 
     /*
@@ -61,8 +61,8 @@ public class ActivityAlerts {
         Instant now = CommonUtils.getTodayInstant();
         Instant reminderInstant = CommonUtils.getTomorrowAlertInstant();
 
-        // if activity is shown before 4 AM then it was for yesterday's activity,
-        // and we need to show another notification after 4:30 PM today.
+        // if activity is shown before 4 PM then it was for yesterday's activity,
+        // and we need to show another notification after 4:30 PM today only if there has been an activity in past 24 h.
         if (now.atZone(ZoneId.systemDefault()).getHour() < 4) {
             reminderInstant = CommonUtils.getTodayInstant(16, 30, 0);
         }

--- a/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
+++ b/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Date;
 
 import static org.intellij.sdk.codesync.Constants.*;
 
@@ -108,7 +109,7 @@ public class ActivityAlerts {
 
             if (canRunDaemon) {
                 // Start the daemon.
-                System.out.println("Calling showActivityAlert.");
+                System.out.printf("[%s]: Calling showActivityAlert.%n", new Date());
                 ProjectUtils.startDaemonProcess(() -> showActivityAlert(project));
             }
         });

--- a/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
+++ b/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
@@ -136,7 +136,6 @@ public class ActivityAlerts {
 
             if (canRunDaemon) {
                 // Start the daemon.
-                System.out.printf("[%s]: Calling showActivityAlert.%n", new Date());
                 ProjectUtils.startDaemonProcess(() -> showActivityAlert(project));
             }
         });

--- a/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
+++ b/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
@@ -77,6 +77,10 @@ public class ActivityAlerts {
         String accessToken = UserFile.getAccessToken();
         String email = UserFile.getEmail();
 
+        if (accessToken == null) {
+            return;
+        }
+
         // If team activity is already shown in other IDE then no need to proceed.
         if (AlertsFile.isTeamActivityAlreadyShown(email)) {
             skipToday();
@@ -85,6 +89,11 @@ public class ActivityAlerts {
 
         CodeSyncClient codeSyncClient = new CodeSyncClient();
         JSONObject jsonResponse = codeSyncClient.getTeamActivity(accessToken);
+
+        if (jsonResponse == null) {
+            return;
+        }
+
         if (hasActivityInTheLastDay(jsonResponse)) {
             boolean isTeamActivity = jsonResponse.containsKey("is_team_activity") &&
                 (boolean) jsonResponse.get("is_team_activity");

--- a/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
+++ b/src/main/java/org/intellij/sdk/codesync/alerts/ActivityAlerts.java
@@ -105,9 +105,9 @@ public class ActivityAlerts {
             Instant checkedFor;
             Instant now = CommonUtils.getTodayInstant();
 
-            // if activity is shown before 4 AM then it was for yesterday's activity,
+            // if activity is shown before 4 PM then it was for yesterday's activity,
             // and we need to show another notification after 4:30 PM today.
-            if (now.atZone(ZoneId.systemDefault()).getHour() < 4) {
+            if (now.atZone(ZoneId.systemDefault()).getHour() < 16) {
                 checkedFor = CommonUtils.getYesterdayInstant();
             } else {
                 checkedFor = CommonUtils.getTodayInstant();

--- a/src/main/java/org/intellij/sdk/codesync/files/AlertsFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/AlertsFile.java
@@ -26,7 +26,7 @@ We can have the following data in alerts.yml
         userEmail:
             checked_at: "2022-07-05"
             checked_for: "2022-07-05"
-            shown_at: 2022-07-05 16:30:27.210
+            shown_at: 2022-07-05T16:30:27.210Z
     user_activity: '2022-07-05 16:30:27.210'
     upgrade_plan: '2022-07-05 21:51:27.210'
  */
@@ -177,7 +177,7 @@ public class AlertsFile extends CodeSyncYmlFile{
             alertDetails.put("checked_at", CommonUtils.formatDate(Date.from(checkedAt), DATE_FORMAT));
         }
         alertDetails.put("checked_for", CommonUtils.formatDate(Date.from(checkedFor), DATE_FORMAT));
-        alertDetails.put("shown_at", CommonUtils.formatDate(Date.from(shownAt), DATE_TIME_FORMAT));
+        alertDetails.put("shown_at", CommonUtils.formatDate(Date.from(shownAt), ISO_DATE_TIME_FORMAT));
 
         teamActivity.put(userEmail, alertDetails);
         alertsFile.contentsMap.put("team_activity", teamActivity);

--- a/src/main/java/org/intellij/sdk/codesync/files/AlertsFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/AlertsFile.java
@@ -141,12 +141,12 @@ public class AlertsFile extends CodeSyncYmlFile{
         );
 
         if (checkedForInstant != null) {
-            Instant yesterday = CommonUtils.getYesterdayInstant();
+            Instant todayInstant = CommonUtils.getTodayInstant();
             // Truncate time information.
-            yesterday = DateUtils.truncate(Date.from(yesterday), Calendar.DATE).toInstant();
+            todayInstant = DateUtils.truncate(Date.from(todayInstant), Calendar.DATE).toInstant();
 
-            // Return true if alert was checked either yesterday or before that
-            return checkedForInstant.equals(yesterday) || checkedForInstant.isBefore(yesterday);
+            // Return true if alert was checked either yesterday or after that
+            return checkedForInstant.equals(todayInstant);
         }
 
         return false;

--- a/src/main/java/org/intellij/sdk/codesync/locks/CodeSyncLock.java
+++ b/src/main/java/org/intellij/sdk/codesync/locks/CodeSyncLock.java
@@ -62,39 +62,41 @@ public class CodeSyncLock {
     /*
     Acquire lock and return `true` if lock was acquired with success or `false` of lock could not be acquired.
     */
-    public void acquireLock() {
+    public boolean acquireLock() {
         // Default expiry is 5 minutes.
         Instant defaultExpiry = Instant.now().plus(5, ChronoUnit.MINUTES);
-        acquireLock(defaultExpiry);
+        return acquireLock(defaultExpiry);
     }
 
     /*
     Acquire lock for the given owner and return `true` if lock was acquired with success
     or `false` of lock could not be acquired.
     */
-    public void acquireLock(String owner) {
+    public boolean acquireLock(String owner) {
         // Default expiry is 5 minutes.
         Instant defaultExpiry = Instant.now().plus(5, ChronoUnit.MINUTES);
-        acquireLock(owner, defaultExpiry);
+        return acquireLock(owner, defaultExpiry);
     }
 
     /*
     Acquire lock with custom expiry.
      */
-    public void acquireLock(Instant expiry) {
-        acquireLock(null, expiry);
+    public boolean acquireLock(Instant expiry) {
+        return acquireLock(null, expiry);
     }
 
     /*
     Acquire lock with custom expiry.
+
+    Return true if lock is acquired with success and false otherwise.
      */
-    public void acquireLock(String owner, Instant expiry) {
+    public boolean acquireLock(String owner, Instant expiry) {
         if (isLockAcquired() && !isLockOwner(owner)) {
             // Lock is acquired by some other process, it can not be acquired.
-            return;
+            return false;
         }
         // If lock is not acquired or if the lock belongs to the same owner then publish the new lock.
-        this.lockFile.publishNewLock(this.lock.getCategory(), expiry, owner);
+        return this.lockFile.publishNewLock(this.lock.getCategory(), expiry, owner);
     }
 
     /*

--- a/src/main/java/org/intellij/sdk/codesync/utils/CommonUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/utils/CommonUtils.java
@@ -344,7 +344,7 @@ public class CommonUtils {
         ZoneId timeZone = ZoneId.systemDefault();
         LocalDateTime yesterdayDateTime = LocalDateTime.now(timeZone);
         ZonedDateTime zonedDateTime = ZonedDateTime.of(yesterdayDateTime, timeZone);
-        zonedDateTime
+        zonedDateTime = zonedDateTime
             .withHour(hour)
             .withMinute(minute)
             .withSecond(second);

--- a/src/main/java/org/intellij/sdk/codesync/utils/CommonUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/utils/CommonUtils.java
@@ -336,4 +336,19 @@ public class CommonUtils {
 
         return zonedDateTime.toInstant();
     }
+
+    /*
+    Get today's instant for the given hour, minute and second.
+    */
+    public static Instant getTodayInstant(int hour, int minute, int second) {
+        ZoneId timeZone = ZoneId.systemDefault();
+        LocalDateTime yesterdayDateTime = LocalDateTime.now(timeZone);
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(yesterdayDateTime, timeZone);
+        zonedDateTime
+            .withHour(hour)
+            .withMinute(minute)
+            .withSecond(second);
+
+        return zonedDateTime.toInstant();
+    }
 }

--- a/src/main/java/org/intellij/sdk/codesync/utils/ProjectUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/utils/ProjectUtils.java
@@ -7,7 +7,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
-import org.intellij.sdk.codesync.Constants;
 import org.intellij.sdk.codesync.exceptions.common.FileNotInModuleError;
 import org.intellij.sdk.codesync.locks.CodeSyncLock;
 import org.intellij.sdk.codesync.state.PluginState;
@@ -19,24 +18,17 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.intellij.sdk.codesync.Constants.DELAY_BETWEEN_BUFFER_TASKS_IN_SECONDS;
-import static org.intellij.sdk.codesync.Constants.POPULATE_BUFFER_DAEMON_LOCK_KEY;
 
 public class ProjectUtils {
 
     /*
     Check if a daemon can be started with the given locking credentials.
     */
-    public static boolean canStartDaemon(String lockType, String lockCategory, String lockOwner) {
+    public static boolean canRunDaemon(String lockType, String lockCategory, String lockOwner) {
         CodeSyncLock codeSyncLock = new CodeSyncLock(lockType, lockCategory);
 
-        if (codeSyncLock.isLockAcquired() && !codeSyncLock.isLockOwner(lockOwner)) {
-            // Return `false` if lock is already acquired by some other process.
-            return false;
-        }
-
         // if lock was not acquired or if it was acquired by this project then refresh the lock and return true.
-        codeSyncLock.acquireLock(lockOwner);
-        return true;
+        return codeSyncLock.acquireLock(lockOwner);
     }
 
     /*

--- a/src/main/java/org/intellij/sdk/codesync/utils/ProjectUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/utils/ProjectUtils.java
@@ -58,6 +58,17 @@ public class ProjectUtils {
         executor.scheduleWithFixedDelay(task, initialDelay, delayBetweenTasks, delayUnit);
     }
 
+    /*
+    Gets the base path for the project and returns that path after normalisation.
+     */
+    public static String getRepoPath(Project project) {
+        String repoPath = project.getBasePath();
+        if (repoPath != null) {
+            return FileUtils.normalizeFilePath(project.getBasePath());
+        }
+        return null;
+    }
+
     public static String getRepoPath(VirtualFile virtualFile, Project project) throws FileNotInModuleError {
         ProjectFileIndex projectFileIndex = ProjectRootManager.getInstance(project).getFileIndex();
         VirtualFile moduleContentRoot = projectFileIndex.getContentRootForFile(virtualFile);


### PR DESCRIPTION
I have removed the usage of absolute paths in locks file as that was causing issues for some users. I have updated the logic for daemon to check the lock inside the recurring task that way if for some reason lock is not available at the time of project startup and no daemon is already running we will be able to run that daemon in the next iteration.

__Testing Instructions:__
1. Make sure daemon are running once per 5 seconds, you can look at the logs and verify the daemons are running and from the timestamp of each message can find the the frequency.
2. Windows path is issue is not really reproduce on my system even in windows OS, but we should stop seeing errors for some windows users.
3. Make sure you are getting team activity alerts after 4:30 PM, also make sure that if alert if you start work at night then you should get notification once before 4 AM for previous day and then again another alert after 4:30 PM for the current day. You may need to directly update `alerts.yml` file to create these scenarios.
