### PR TITLE
feat: Removed changes handler logic from main thread into a separate thread.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.19.1] - 2023-02-22
+- Fixed a bug that was causing failure in the detection of new line characters.
+- Removed changes handler logic from main thread into a separate thread
+
 ## [3.18.5] - 2022-01-28
 - Fixed date time formatting issues for alerts file.
 - Fixed a logic issue against activity data returned by server.

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'com.codesync'
-version '3.19.0'
+version '3.19.1'
 
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"

--- a/src/main/java/kt/org/intellij/sdk/codesync/tasks/TaskExecutor.kt
+++ b/src/main/java/kt/org/intellij/sdk/codesync/tasks/TaskExecutor.kt
@@ -1,0 +1,15 @@
+package kt.org.intellij.sdk.codesync.tasks
+
+object TaskExecutor {
+    private var taskQueue: TaskQueue = TaskQueue();
+
+    fun execute(runnable: Runnable) {
+        println("execute called.")
+        taskQueue.addTask(runnable)
+    }
+
+    fun start() {
+        println("Starting ...");
+        taskQueue.start()
+    }
+}

--- a/src/main/java/kt/org/intellij/sdk/codesync/tasks/TaskQueue.kt
+++ b/src/main/java/kt/org/intellij/sdk/codesync/tasks/TaskQueue.kt
@@ -1,0 +1,29 @@
+package kt.org.intellij.sdk.codesync.tasks
+
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+
+class TaskQueue {
+    private val queue: BlockingQueue<Runnable> = LinkedBlockingQueue()
+
+    private inner class TaskExecutor : Thread() {
+        override fun run() {
+            try {
+                while (true) {
+                    val task = queue.take()
+                    task.run()
+                }
+            } catch (e: InterruptedException) {
+                // No action needed.
+            }
+        }
+    }
+
+    fun start() {
+        TaskExecutor().start()
+    }
+
+    fun addTask(task: Runnable) {
+        queue.add(task)
+    }
+}

--- a/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
@@ -201,7 +201,6 @@ public class HandleBuffer {
             }
 
             System.out.printf("Processing diff file: %s.\n", diffFile.originalDiffFile.getPath());
-            System.out.printf("Processing diff: %s%n", diffFile.diff);
 
             if (!configFile.repos.containsKey(diffFile.repoPath)) {
                 CodeSyncLogger.error(String.format("Repo `%s` is in buffer but not in configFile.yml.\n", diffFile.repoPath));
@@ -477,7 +476,7 @@ public class HandleBuffer {
         } catch (FileInfoError error) {
             error.printStackTrace();
         }
-        String shadowText = FileUtils.readLineByLineJava8(shadowPath);
+        String shadowText = FileUtils.readFileToString(shadowPath.toFile());
         diff = CommonUtils.computeDiff(shadowText, "");
         cleanUpDeletedDiff(configFile,  configRepo, configRepoBranch, diffFile, shadowPath);
 

--- a/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
@@ -201,6 +201,7 @@ public class HandleBuffer {
             }
 
             System.out.printf("Processing diff file: %s.\n", diffFile.originalDiffFile.getPath());
+            System.out.printf("Processing diff: %s%n", diffFile.diff);
 
             if (!configFile.repos.containsKey(diffFile.repoPath)) {
                 CodeSyncLogger.error(String.format("Repo `%s` is in buffer but not in configFile.yml.\n", diffFile.repoPath));
@@ -379,7 +380,6 @@ public class HandleBuffer {
                             return;
                         }
                         System.out.printf("Diff file '%s' successfully processed.\n", diffFilePath);
-
                         if (DiffFile.delete(diffFilePath)) {
                             System.out.printf("Diff file '%s' successfully deleted.\n", diffFilePath);
                         } else {

--- a/src/main/java/org/intellij/sdk/codesync/ProjectOpenCloseListener.java
+++ b/src/main/java/org/intellij/sdk/codesync/ProjectOpenCloseListener.java
@@ -45,7 +45,6 @@ import static org.intellij.sdk.codesync.codeSyncSetup.CodeSyncSetup.createSystem
  */
 public class ProjectOpenCloseListener implements ProjectManagerListener {
   private static final Map<String, Pair<Project, DocumentListener>> changeHandlers = new HashMap<>();
-  private static Integer eventCount = 0;
 
   /**
    * Invoked on project open.
@@ -174,8 +173,7 @@ public class ProjectOpenCloseListener implements ProjectManagerListener {
       @Override
       public void documentChanged(@NotNull DocumentEvent event) {
         if (!project.isDisposed()){
-          eventCount += 1;
-          ChangesHandler(event, project, eventCount);
+          ChangesHandler(event, project);
         }
       }
     };

--- a/src/main/java/org/intellij/sdk/codesync/ProjectOpenCloseListener.java
+++ b/src/main/java/org/intellij/sdk/codesync/ProjectOpenCloseListener.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.newvfs.BulkFileListener;
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
 import com.intellij.serviceContainer.AlreadyDisposedException;
+import kt.org.intellij.sdk.codesync.tasks.TaskExecutor;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.intellij.sdk.codesync.alerts.ActivityAlerts;
 import org.intellij.sdk.codesync.codeSyncSetup.CodeSyncSetup;
@@ -44,6 +45,7 @@ import static org.intellij.sdk.codesync.codeSyncSetup.CodeSyncSetup.createSystem
  */
 public class ProjectOpenCloseListener implements ProjectManagerListener {
   private static final Map<String, Pair<Project, DocumentListener>> changeHandlers = new HashMap<>();
+  private static Integer eventCount = 0;
 
   /**
    * Invoked on project open.
@@ -89,6 +91,9 @@ public class ProjectOpenCloseListener implements ProjectManagerListener {
 
     // Start alerts daemon
     ActivityAlerts.startActivityAlertDaemon(project);
+
+    // Start the task executor.
+    TaskExecutor.INSTANCE.start();
 
     StartupManagerEx.getInstance(project).runWhenProjectIsInitialized(() -> {
       if (project.isDisposed()) return;
@@ -169,7 +174,8 @@ public class ProjectOpenCloseListener implements ProjectManagerListener {
       @Override
       public void documentChanged(@NotNull DocumentEvent event) {
         if (!project.isDisposed()){
-          ChangesHandler(event, project);
+          eventCount += 1;
+          ChangesHandler(event, project, eventCount);
         }
       }
     };

--- a/src/main/java/org/intellij/sdk/codesync/utils/FileUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/utils/FileUtils.java
@@ -29,27 +29,6 @@ import static org.intellij.sdk.codesync.Constants.IGNORABLE_DIRECTORIES;
 
 public class FileUtils
 {
-    public static String readLineByLineJava8(Path filePath) {
-        return readLineByLineJava8(filePath.toString());
-    }
-
-    //Read file content into the string with - Files.lines(Path path, Charset cs)
-    public static String readLineByLineJava8(String filePath)
-    {
-        StringBuilder contentBuilder = new StringBuilder();
-
-        try (Stream<String> stream = Files.lines( Paths.get(filePath), StandardCharsets.UTF_8))
-        {
-            stream.forEach(s -> contentBuilder.append(s).append("\n"));
-        }
-        catch (IOException e)
-        {
-            e.printStackTrace();
-        }
-
-        return contentBuilder.toString();
-    }
-
     public static String readFileToString(String filePath) {
         return readFileToString(new File(filePath));
     }


### PR DESCRIPTION
I have made this change to test document changes to be handled in a separate thread. If this goes well we can look at expanding threading usage for other cases as well.

**Testing Instructions:**
1. Start the Plugin and make sure changes made to the files are syncing correctly. Also, see if you observe any performance related changes as well.