### PR TITLE
feat: Added handling for exceptions in the repo init process.

### DIFF
--- a/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
@@ -62,9 +62,9 @@ public class HandleBuffer {
             return true;
         }
 
-        if (configFile.isRepoDisconnected(diffFile.repoPath)) {
+        if (!configFile.isRepoActive(diffFile.repoPath)) {
             CodeSyncLogger.info(String.format(
-                "Repo %s is disconnected.", diffFile.repoPath
+                "Repo %s is not active.", diffFile.repoPath
             ));
             diffFile.delete();
             return true;

--- a/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
+++ b/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
@@ -547,10 +547,16 @@ public class CodeSyncSetup {
                     (String) userObject.get("iam_secret_key")
             );
         } catch (ClassCastException err) {
-            if (isSyncingBranch) {
-                configRepo.deleteRepoBranch(branchName);
-            } else {
-                configFile.deleteRepo(repoPath);
+            try {
+                if (isSyncingBranch) {
+                    configFile.publishBranchRemoval(configRepo, branchName);
+                } else {
+                    configFile.publishRepoRemoval(repoPath);
+                }
+            } catch (InvalidConfigFileError error) {
+                CodeSyncLogger.error(String.format(
+                    "Error removing repo from config file after init error. Error: %s", error.getMessage()
+                ));
             }
             CodeSyncLogger.critical(String.format(
                     "Error parsing the response of /init endpoint. Error: %s", err.getMessage()
@@ -571,10 +577,16 @@ public class CodeSyncSetup {
                     email
                 );
 
-                if (isSyncingBranch) {
-                    configRepo.deleteRepoBranch(branchName);
-                } else {
-                    configFile.deleteRepo(repoPath);
+                try {
+                    if (isSyncingBranch) {
+                        configFile.publishBranchRemoval(configRepo, branchName);
+                    } else {
+                        configFile.publishRepoRemoval(repoPath);
+                    }
+                } catch (InvalidConfigFileError error) {
+                    CodeSyncLogger.error(String.format(
+                        "Error removing repo from config file after init error. Error: %s", error.getMessage()
+                    ));
                 }
 
                 return false;
@@ -590,10 +602,16 @@ public class CodeSyncSetup {
                     email
             );
 
-            if (isSyncingBranch) {
-                configRepo.deleteRepoBranch(branchName);
-            } else {
-                configFile.deleteRepo(repoPath);
+            try {
+                if (isSyncingBranch) {
+                    configFile.publishBranchRemoval(configRepo, branchName);
+                } else {
+                    configFile.publishRepoRemoval(repoPath);
+                }
+            } catch (InvalidConfigFileError error) {
+                CodeSyncLogger.error(String.format(
+                    "Error removing repo from config file after init error. Error: %s", error.getMessage()
+                ));
             }
 
             return false;

--- a/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
+++ b/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
@@ -547,6 +547,11 @@ public class CodeSyncSetup {
                     (String) userObject.get("iam_secret_key")
             );
         } catch (ClassCastException err) {
+            if (isSyncingBranch) {
+                configRepo.deleteRepoBranch(branchName);
+            } else {
+                configFile.deleteRepo(repoPath);
+            }
             CodeSyncLogger.critical(String.format(
                     "Error parsing the response of /init endpoint. Error: %s", err.getMessage()
             ));
@@ -566,6 +571,12 @@ public class CodeSyncSetup {
                     email
                 );
 
+                if (isSyncingBranch) {
+                    configRepo.deleteRepoBranch(branchName);
+                } else {
+                    configFile.deleteRepo(repoPath);
+                }
+
                 return false;
             }
 
@@ -578,6 +589,12 @@ public class CodeSyncSetup {
                     String.format("Error parsing the response of /init endpoint. Error: %s", err.getMessage()),
                     email
             );
+
+            if (isSyncingBranch) {
+                configRepo.deleteRepoBranch(branchName);
+            } else {
+                configFile.deleteRepo(repoPath);
+            }
 
             return false;
         }

--- a/src/main/java/org/intellij/sdk/codesync/files/ConfigFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/ConfigFile.java
@@ -144,7 +144,7 @@ public class ConfigFile extends CodeSyncYmlFile {
             return false;
         }
 
-        return !repo.isDisconnected && !repo.branches.isEmpty() && repo.hasValidEmail();
+        return !repo.isDisconnected && !repo.branches.isEmpty() && repo.hasValidEmail() && repo.hasValidId();
     }
 
     public boolean isRepoDisconnected(String repoPath) {

--- a/src/main/java/org/intellij/sdk/codesync/files/ConfigRepo.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/ConfigRepo.java
@@ -64,8 +64,13 @@ public class ConfigRepo {
         return this.branches.get(branchName);
     }
     public boolean containsBranch(String branchName) { return this.branches.containsKey(branchName); }
+
     public boolean hasValidEmail() {
         return this.email != null && !this.email.isEmpty();
+    }
+
+    public boolean hasValidId() {
+        return this.id != null;
     }
 
     public void updateRepoBranch(String branchName, ConfigRepoBranch newBranch) {


### PR DESCRIPTION
This PR adds handling for invalid repo entries, invalid repo entries mean repos where `id`, `email` are `null`. This can happen if repo-sync errors out mid-way. I have added handling for these error scenarios as well to make sure dangling `null` values are removed in such cases.

__Testing Instructions:__
1. Add a new file to a repo whose config file entry has null in the `id` field, (You can se `id `to `null` manually for testing as well.)
2. Make sure repo entry is not present with `null` values if repo-sync errors out, e.g. when user has reached pricing limits. Or if user loses internet connection during sync.