### PR TITLE
Updated for multi-module issues and branch-sync issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.20.1] - 2023-04-09
+-  Fixed handling for multi-module projects in languages that support modules such as java. These were being considered as separate repo by the plugin.
+- Added fixes for sync prompt at the start, it was incorrectly prompting user to sync the repo if user creates a new branch offline for an already synced repo.
+- Fixed invalid payload issue for branch syncing process, specifically `is_public` was missing and causing an error.
+- Improved messaging of repo in sync message.
+
 ## [3.20.0] - 2023-03-23
 - Added support for latest intelliJ IDE version.
 - Added fixes for dialog related issues on some systems.

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ dependencies {
   // Configuration for tests.
   testImplementation('org.junit.jupiter:junit-jupiter-api:5.4.2')
   testImplementation('org.junit.jupiter:junit-jupiter-engine:5.4.2')
+  testImplementation('org.mockito:mockito-core:3.+')
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'com.codesync'
-version '3.20.0'
+version '3.20.1'
 
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"

--- a/src/main/java/org/intellij/sdk/codesync/Constants.java
+++ b/src/main/java/org/intellij/sdk/codesync/Constants.java
@@ -136,7 +136,7 @@ public final class Constants {
         public static final String BRANCH_INIT_FAILURE_MESSAGE = "Branch '%s' could not be initialized successfully, please try again later. If problem persists then contact support.";
 
         public static final String REPO_SYNC_IN_PROGRESS_MESSAGE = "Repo '%s' is being synced with CodeSync.";
-        public static final String REPO_IN_SYNC_MESSAGE = "Repo '%s' is synced with CodeSync.";
+        public static final String REPO_IN_SYNC_MESSAGE = "Repo '%s' is in sync with CodeSync.";
         public static final String REPO_ALREADY_IN_SYNC_MESSAGE = "Repo '%s' is already being synced with CodeSync.";
 
         public static final String LOGIN_REQUIRED_FOR_SYNC_MESSAGE = "You need to login to sync repo. Please login and then try again.";

--- a/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
@@ -347,7 +347,7 @@ public class HandleBuffer {
             return;
         }
 
-        if (configFile.isRepoDisconnected(currentRepo)) {
+        if (!configFile.isRepoActive(currentRepo)) {
             CodeSyncLogger.info("Repo is disconnected so, skipping the diffs.");
             return;
         }

--- a/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
+++ b/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
@@ -146,7 +146,7 @@ public class CodeSyncSetup {
         try {
             ConfigFile configFile = new ConfigFile(CONFIG_PATH);
 
-            if (!configFile.isRepoActive(repoPath)) {
+            if (!configFile.isRepoActive(repoPath) || isSyncingBranch) {
                 String branchName = Utils.GetGitBranch(repoPath);
                 codeSyncProgressIndicator.setMileStone(InitRepoMilestones.CHECK_USER_ACCESS);
                 boolean hasAccessToken = checkUserAccess(project, repoPath, repoName, branchName, skipSyncPrompt, isSyncingBranch);
@@ -176,9 +176,10 @@ public class CodeSyncSetup {
 
                     if (shouldSyncRepo) {
                         syncRepo(repoPath, repoName, branchName, project, codeSyncProgressIndicator, false);
+                        reposBeingSynced.remove(repoPath);
                     }
                 }
-            } else {
+            } else if (!isSyncingBranch) {
                 NotificationManager.notifyInformation(
                         String.format(Notification.REPO_IN_SYNC_MESSAGE, repoName),
                         project
@@ -511,6 +512,8 @@ public class CodeSyncSetup {
                 },
                 ModalityState.defaultModalityState()
             );
+        } else {
+            payload.put("is_public", false);
         }
 
         payload.put("name", repoName);

--- a/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
+++ b/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
@@ -145,9 +145,8 @@ public class CodeSyncSetup {
     public static void setupCodeSyncRepo(Project project, String repoPath, String repoName, CodeSyncProgressIndicator codeSyncProgressIndicator, boolean skipSyncPrompt, boolean isSyncingBranch) {
         try {
             ConfigFile configFile = new ConfigFile(CONFIG_PATH);
-            ConfigRepo configRepo = configFile.getRepo(repoPath);
 
-            if (configFile.isRepoDisconnected(repoPath) || !configRepo.isSuccessfullySyncedWithBranch()) {
+            if (!configFile.isRepoActive(repoPath)) {
                 String branchName = Utils.GetGitBranch(repoPath);
                 codeSyncProgressIndicator.setMileStone(InitRepoMilestones.CHECK_USER_ACCESS);
                 boolean hasAccessToken = checkUserAccess(project, repoPath, repoName, branchName, skipSyncPrompt, isSyncingBranch);
@@ -179,7 +178,7 @@ public class CodeSyncSetup {
                         syncRepo(repoPath, repoName, branchName, project, codeSyncProgressIndicator, false);
                     }
                 }
-            } else if (!configFile.isRepoDisconnected(repoPath)) {
+            } else {
                 NotificationManager.notifyInformation(
                         String.format(Notification.REPO_IN_SYNC_MESSAGE, repoName),
                         project
@@ -440,7 +439,7 @@ public class CodeSyncSetup {
             filesData.put(relativeFilePath, item);
         }
         ConfigRepo configRepo;
-        if(configFile.isRepoDisconnected(repoPath)) {
+        if(!configFile.isRepoActive(repoPath)) {
             configRepo = new ConfigRepo(repoPath);
             configRepo.updateRepoBranch(branchName, new ConfigRepoBranch(branchName, branchFiles));
             configFile.updateRepo(repoPath, configRepo);

--- a/src/main/java/org/intellij/sdk/codesync/files/ConfigFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/ConfigFile.java
@@ -146,13 +146,4 @@ public class ConfigFile extends CodeSyncYmlFile {
 
         return !repo.isDisconnected && !repo.branches.isEmpty() && repo.hasValidEmail() && repo.hasValidId();
     }
-
-    public boolean isRepoDisconnected(String repoPath) {
-        ConfigRepo repo = this.getRepo(repoPath);
-        if (repo == null) {
-            return true;
-        }
-
-        return repo.isDisconnected;
-    }
 }

--- a/src/test/java/TestUtils.kt
+++ b/src/test/java/TestUtils.kt
@@ -1,8 +1,15 @@
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.util.io.FileUtil
+import java.nio.file.Paths
 
 object CodeSyncTestUtils {
+    private val DIRECTORY_PATH = Paths.get(System.getProperty("user.dir"), "test_data").toAbsolutePath()
+
     fun getTestDataPath(): String {
+        return DIRECTORY_PATH.toString();
+    }
+
+    fun getTempPath(): String {
         return FileUtil.toCanonicalPath("${PathManager.getTempPath()}/")
     }
 }

--- a/src/test/java/TestUtils.kt
+++ b/src/test/java/TestUtils.kt
@@ -1,0 +1,8 @@
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.util.io.FileUtil
+
+object CodeSyncTestUtils {
+    fun getTestDataPath(): String {
+        return FileUtil.toCanonicalPath("${PathManager.getTempPath()}/")
+    }
+}

--- a/src/test/java/org/intellij/sdk/codesync/utils/ProjectUtilsTest.kt
+++ b/src/test/java/org/intellij/sdk/codesync/utils/ProjectUtilsTest.kt
@@ -1,0 +1,225 @@
+package org.intellij.sdk.codesync.utils
+
+import CodeSyncTestUtils
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.vfs.VirtualFile
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import java.util.*
+
+
+class ProjectUtilsTest {
+
+    /*
+    Validate the behavior of `getAllContentRoots` method from ProjectUtils.
+    */
+    @Test
+    fun validateGetAllContentRootsWithSingleRoot() {
+        val project: Project = Mockito.mock(Project::class.java)
+        val projectRootManager: ProjectRootManager = Mockito.mock(ProjectRootManager::class.java)
+        val testDataPath = CodeSyncTestUtils.getTestDataPath()
+        val mockFiles = arrayOf(
+            // Three repos, with one parent and 2 nested.
+            Mockito.mock(VirtualFile::class.java).apply { Mockito.`when`(getCanonicalPath()).thenReturn("$testDataPath/test-repo") },
+            Mockito.mock(VirtualFile::class.java).apply { Mockito.`when`(getCanonicalPath()).thenReturn("$testDataPath/test-repo/nested-repo") },
+            Mockito.mock(VirtualFile::class.java).apply { Mockito.`when`(getCanonicalPath()).thenReturn("$testDataPath/test-repo/another-nested-repo") }
+        )
+
+        // configure the mock objects
+        Mockito.`when`(projectRootManager.contentRoots).thenReturn(mockFiles)
+        Mockito.`when`(ProjectRootManager.getInstance(project)).thenReturn(projectRootManager)
+
+        val contentRoots = ProjectUtils.getAllContentRoots(project);
+        assert(contentRoots.size == 1)
+        assert(contentRoots[0].canonicalPath == "$testDataPath/test-repo")
+    }
+
+    @Test
+    fun validateGetAllContentRootsWithMultipleRoots() {
+        val project: Project = Mockito.mock(Project::class.java)
+        val projectRootManager: ProjectRootManager = Mockito.mock(ProjectRootManager::class.java)
+        val testDataPath = CodeSyncTestUtils.getTestDataPath()
+        val mockFiles = arrayOf(
+            // Three repos, with one parent and 2 nested.
+            Mockito.mock(VirtualFile::class.java).apply { Mockito.`when`(getCanonicalPath()).thenReturn("$testDataPath/test-repo") },
+            Mockito.mock(VirtualFile::class.java).apply { Mockito.`when`(getCanonicalPath()).thenReturn("$testDataPath/test-repo/nested-repo") },
+            Mockito.mock(VirtualFile::class.java).apply { Mockito.`when`(getCanonicalPath()).thenReturn("$testDataPath/test-repo/another-nested-repo") },
+
+            // 2 repos, with one parent and 1 nested.
+            Mockito.mock(VirtualFile::class.java).apply { Mockito.`when`(getCanonicalPath()).thenReturn("$testDataPath/another-repo") },
+            Mockito.mock(VirtualFile::class.java).apply { Mockito.`when`(getCanonicalPath()).thenReturn("$testDataPath/another-repo/nested-repo") },
+
+            // Single repo.
+            Mockito.mock(VirtualFile::class.java).apply { Mockito.`when`(getCanonicalPath()).thenReturn("$testDataPath/third-repo/different-path") },
+        )
+
+        // configure the mock objects
+        Mockito.`when`(projectRootManager.contentRoots).thenReturn(mockFiles)
+        Mockito.`when`(ProjectRootManager.getInstance(project)).thenReturn(projectRootManager)
+
+        val contentRoots = ProjectUtils.getAllContentRoots(project);
+
+        // Validate there are 3 repos.
+        assert(contentRoots.size == 3)
+
+        val expectedRepos = arrayOf(
+            "$testDataPath/test-repo",
+            "$testDataPath/another-repo",
+            "$testDataPath/third-repo/different-path",
+        )
+        val result = Arrays.stream(contentRoots).distinct().map { contentRoot: VirtualFile? -> contentRoot?.canonicalPath }.toArray();
+        assert(result.contentEquals(expectedRepos))
+    }
+
+    @Test
+    fun validateGetAllContentRootsWithMultipleRootsNoChild() {
+        val project: Project = Mockito.mock(Project::class.java)
+        val projectRootManager: ProjectRootManager = Mockito.mock(ProjectRootManager::class.java)
+        val testDataPath = CodeSyncTestUtils.getTestDataPath()
+        val mockFiles = arrayOf(
+            // 5 repos no child
+            Mockito.mock(VirtualFile::class.java).apply { Mockito.`when`(getCanonicalPath()).thenReturn("$testDataPath/test-repo") },
+            Mockito.mock(VirtualFile::class.java).apply { Mockito.`when`(getCanonicalPath()).thenReturn("$testDataPath/another-repo") },
+            Mockito.mock(VirtualFile::class.java).apply { Mockito.`when`(getCanonicalPath()).thenReturn("$testDataPath/third-repo/different-path") },
+            Mockito.mock(VirtualFile::class.java).apply { Mockito.`when`(getCanonicalPath()).thenReturn("$testDataPath/my-path/fourth-repo") },
+            Mockito.mock(VirtualFile::class.java).apply { Mockito.`when`(getCanonicalPath()).thenReturn("$testDataPath/my-path/fifth-repo") },
+        )
+
+        // configure the mock objects
+        Mockito.`when`(projectRootManager.contentRoots).thenReturn(mockFiles)
+        Mockito.`when`(ProjectRootManager.getInstance(project)).thenReturn(projectRootManager)
+
+        val contentRoots = ProjectUtils.getAllContentRoots(project);
+
+        // Validate there are 5 repos.
+        assert(contentRoots.size == 5)
+
+        val expectedRepos = arrayOf(
+            "$testDataPath/test-repo",
+            "$testDataPath/another-repo",
+            "$testDataPath/third-repo/different-path",
+            "$testDataPath/my-path/fourth-repo",
+            "$testDataPath/my-path/fifth-repo",
+        )
+        val result = Arrays.stream(contentRoots).distinct().map { contentRoot: VirtualFile? -> contentRoot?.canonicalPath }.toArray();
+        assert(result.contentEquals(expectedRepos))
+    }
+
+    @Test
+    fun validateIsChild() {
+        val testDataPath = CodeSyncTestUtils.getTestDataPath()
+
+        // Assert returns true for child path.
+        assert(
+            ProjectUtils.isChild(
+                "$testDataPath/test-repo/nested-repo",
+                "$testDataPath/test-repo"
+            )
+        )
+        // Assert returns true for child path.
+        assert(
+            ProjectUtils.isChild(
+                "$testDataPath/test-repo/another-nested-repo",
+                "$testDataPath/test-repo"
+            )
+        )
+
+        // Assert returns false if first path is not a child of the second.
+        assert(
+            !ProjectUtils.isChild(
+                "$testDataPath/first-repo",
+                "$testDataPath/second-repo"
+            )
+        )
+
+        // Assert returns false if first path is not a child of the second.
+        assert(
+            !ProjectUtils.isChild(
+                "$testDataPath/first-path",
+                "$testDataPath/first-path/nested-repo"
+            )
+        )
+         // Assert returns false if first path is the same as the second.
+        assert(
+            !ProjectUtils.isChild(
+                "$testDataPath/first-path",
+                "$testDataPath/first-path"
+            )
+        )
+        // Assert returns trailing slash does not cause a problem.
+        assert(
+            !ProjectUtils.isChild(
+                "$testDataPath/first-path/",
+                "$testDataPath/first-path"
+            )
+        )
+
+        assert(
+            ProjectUtils.isChild(
+                "$testDataPath/test-repo/nested-repo/",
+                "$testDataPath/test-repo/"
+            )
+        )
+    }
+
+    @Test
+    fun validateIsParent() {
+        val testDataPath = CodeSyncTestUtils.getTestDataPath()
+
+        // Assert returns true for parent path.
+        assert(
+            ProjectUtils.isParent(
+                "$testDataPath/test-repo",
+                "$testDataPath/test-repo/nested-repo",
+            )
+        )
+        // Assert returns true for parent path.
+        assert(
+            ProjectUtils.isParent(
+                "$testDataPath/test-repo",
+                "$testDataPath/test-repo/another-nested-repo",
+            )
+        )
+
+        // Assert returns true if first path is the same as the second.
+        assert(
+            ProjectUtils.isParent(
+                "$testDataPath/first-path",
+                "$testDataPath/first-path"
+            )
+        )
+
+        // Assert returns trailing slash does not cause a problem.
+        assert(
+            ProjectUtils.isParent(
+                "$testDataPath/first-path",
+                "$testDataPath/first-path/"
+            )
+        )
+
+        assert(
+            !ProjectUtils.isParent(
+                "$testDataPath/test-repo/nested-repo/",
+                "$testDataPath/test-repo/"
+            )
+        )
+
+        // Assert returns false if first path is not a parent of the second.
+        assert(
+            !ProjectUtils.isParent(
+                "$testDataPath/first-repo",
+                "$testDataPath/second-repo"
+            )
+        )
+
+        // Assert returns false if first path is not a parent of the second.
+        assert(
+            !ProjectUtils.isParent(
+                "$testDataPath/first-path/nested-repo",
+                "$testDataPath/first-path",
+            )
+        )
+    }
+
+}


### PR DESCRIPTION
__Description:__
Here is a list of changes included in this PR.

1. Fixed handling for multi-module projects in languages that support modules such as java. These were being considered as separate repo by the plugin.
2. Added fixes for sync prompt at the start, it was incorrectly prompting user to sync the repo if user creates a new branch offline for an already synced repo.
3. Fixed invalid payload issue for branch syncing process, specifically `is_public` was missing and causing an error.
4. Improved messaging of repo in sync message.

**Testing Instructions:**
- Sync a new repo. Make sure it gets synced successfully.
- Disconnect a repo and then close and open the project without closing the IDE, user should be prompted to sync the repo again.
-  Disconnect the repo and sync using codesync menu.
- Change the branch of a repo and make sure new branch gets uploaded
- Close the project create another new branch and start the project again. make sure it does not ask to start the syncing again. And syncs the new branch in the background.
