### PR TITLE
Handling for invalid config file, some bug fixes and code refactoring.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.20.2] - 2023-04-14
+- Added synchronization logic for writes to config files, a locking mechanism would allow multiple threads write to the config file.
+- Added handling for invalid config files, config file will be emptied if its contents are not valid.
+- Changes for inactive repositories would be ignored now, previously diff files were being created causing buffer size increase.
+- Offline changes for inactive repositories will be ignored.
+- Updated logic to use correct initial values for fields such as `isDisconnected`, `pauseNotification` and `isDeleted` for newly synced repos.
+
 ## [3.20.1] - 2023-04-09
 -  Fixed handling for multi-module projects in languages that support modules such as java. These were being considered as separate repo by the plugin.
 - Added fixes for sync prompt at the start, it was incorrectly prompting user to sync the repo if user creates a new branch offline for an already synced repo.

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'com.codesync'
-version '3.20.1'
+version '3.20.2'
 
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"

--- a/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
@@ -6,7 +6,6 @@ import org.intellij.sdk.codesync.clients.CodeSyncClient;
 import org.intellij.sdk.codesync.clients.CodeSyncWebSocketClient;
 import org.intellij.sdk.codesync.exceptions.*;
 import org.intellij.sdk.codesync.files.*;
-import org.intellij.sdk.codesync.locks.CodeSyncLock;
 import org.intellij.sdk.codesync.repoManagers.DeletedRepoManager;
 import org.intellij.sdk.codesync.repoManagers.OriginalsRepoManager;
 import org.intellij.sdk.codesync.repoManagers.ShadowRepoManager;

--- a/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
@@ -183,13 +183,8 @@ public class PopulateBuffer {
             String repoName = Paths.get(repoPath).getFileName().toString();
             ConfigRepo configRepo = configRepoEntry.getValue();
 
-            if (configRepo.isDisconnected) {
-                // No need to check updates for this repo.
-                continue;
-            }
-
-            if (!configRepo.hasValidEmail()) {
-                // Repo does not have a correct email address, skipping this as well.
+            if (!configRepo.isActive()) {
+                // Repo is not active so no need to check updates for this repo.
                 continue;
             }
 
@@ -276,7 +271,7 @@ public class PopulateBuffer {
                 ));
             }
 
-            if (!populateBuffer.configRepo.isDisconnected) {
+            if (populateBuffer.configRepo.isActive()) {
                 if (populateBuffer.isModifiedSinceLastSync()) {
                     diffsForFileUpdates = populateBuffer.getDiffsForFileUpdates();
                 }

--- a/src/main/java/org/intellij/sdk/codesync/Utils.java
+++ b/src/main/java/org/intellij/sdk/codesync/Utils.java
@@ -39,7 +39,7 @@ public class Utils {
         }
         try {
             ConfigFile configFile = new ConfigFile(CONFIG_PATH);
-            return !configFile.hasRepo(repoPath);
+            return !configFile.isRepoActive(repoPath);
         } catch (InvalidConfigFileError e) {
             return true;
         }

--- a/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
+++ b/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
@@ -693,6 +693,9 @@ public class CodeSyncSetup {
         ConfigRepoBranch configRepoBranch = new ConfigRepoBranch(branchName, filePathAndIds);
         configRepo.id = repoId;
         configRepo.email = userEmail;
+        configRepo.isDisconnected = false;
+        configRepo.isDeleted = false;
+        configRepo.pauseNotification = false;
 
         try {
             configRepo.updateRepoBranch(branchName, configRepoBranch);

--- a/src/main/java/org/intellij/sdk/codesync/files/CodeSyncYmlFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/CodeSyncYmlFile.java
@@ -12,6 +12,8 @@ import java.io.*;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 /*
@@ -27,15 +29,15 @@ abstract public class CodeSyncYmlFile {
 
     public Map<String, Object> readYml() throws FileNotFoundException, InvalidYmlFileError {
         Yaml yaml = new Yaml();
-        InputStream inputStream;
-        inputStream = new FileInputStream(this.getYmlFile());
-        String text = null;
+        Path filePath = this.getYmlFile().toPath();
 
-        try (Reader reader = new InputStreamReader(inputStream)) {
-            text = CharStreams.toString(reader);
+        try (Reader reader = new InputStreamReader(Files.newInputStream(filePath))) {
+            String text = CharStreams.toString(reader);
             return yaml.load(text);
-        } catch (IOException | YAMLException e) {
+        } catch (YAMLException e) {
             throw new InvalidYmlFileError(e.getMessage());
+        } catch (IOException e) {
+            throw new FileNotFoundException(e.getMessage());
         }
     }
 
@@ -122,6 +124,8 @@ abstract public class CodeSyncYmlFile {
         try {
             FileWriter writer = new FileWriter(ymlFile);
             writer.write("{}");
+            writer.flush();
+            writer.close();
         } catch (IOException | YAMLException e) {
             // Ignore errors
             CodeSyncLogger.error(String.format(

--- a/src/main/java/org/intellij/sdk/codesync/files/CodeSyncYmlFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/CodeSyncYmlFile.java
@@ -55,6 +55,8 @@ abstract public class CodeSyncYmlFile {
         try {
             FileWriter writer = new FileWriter(ymlFile);
             yaml.dump(yamlConfig, writer);
+            writer.flush();
+            writer.close();
         } catch (IOException | YAMLException e) {
             throw new InvalidYmlFileError(e.getMessage());
         }

--- a/src/main/java/org/intellij/sdk/codesync/files/ConfigFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/ConfigFile.java
@@ -30,7 +30,10 @@ public class ConfigFile extends CodeSyncYmlFile {
 
         try {
             this.contentsMap = this.readYml();
-        } catch (FileNotFoundException | InvalidYmlFileError e) {
+        } catch (InvalidYmlFileError e) {
+            ConfigFile.removeFileContents(this.getYmlFile());
+            CodeSyncLogger.error("Removed contents of the config file after facing invalid yaml error.");
+        } catch (FileNotFoundException e) {
             throw new InvalidConfigFileError(e.getMessage());
         }
 
@@ -170,6 +173,6 @@ public class ConfigFile extends CodeSyncYmlFile {
             return false;
         }
 
-        return !repo.isDisconnected && !repo.branches.isEmpty() && repo.hasValidEmail() && repo.hasValidId();
+        return repo.isActive();
     }
 }

--- a/src/main/java/org/intellij/sdk/codesync/files/ConfigFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/ConfigFile.java
@@ -10,6 +10,7 @@ import org.intellij.sdk.codesync.CodeSyncLogger;
 import org.intellij.sdk.codesync.exceptions.FileLockedError;
 import org.intellij.sdk.codesync.exceptions.InvalidConfigFileError;
 import org.intellij.sdk.codesync.exceptions.InvalidYmlFileError;
+import org.intellij.sdk.codesync.state.StateUtils;
 
 
 public class ConfigFile extends CodeSyncYmlFile {
@@ -32,6 +33,7 @@ public class ConfigFile extends CodeSyncYmlFile {
             this.contentsMap = this.readYml();
         } catch (InvalidYmlFileError e) {
             ConfigFile.removeFileContents(this.getYmlFile());
+            StateUtils.reloadState(StateUtils.getGlobalState().project);
             CodeSyncLogger.error("Removed contents of the config file after facing invalid yaml error.");
         } catch (FileNotFoundException e) {
             throw new InvalidConfigFileError(e.getMessage());

--- a/src/main/java/org/intellij/sdk/codesync/files/ConfigRepo.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/ConfigRepo.java
@@ -89,6 +89,13 @@ public class ConfigRepo {
     }
 
     /*
+        Check if the repo is actively being synced with the server.
+    */
+    public boolean isActive() {
+        return !isDisconnected && isSynced() && hasValidId() && hasValidEmail();
+    }
+
+    /*
     Make sure the current branch is successfully synced with the server.
      */
     public boolean isSuccessfullySyncedWithBranch() {

--- a/src/main/java/org/intellij/sdk/codesync/files/DiffFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/DiffFile.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Date;
 
 
+import org.intellij.sdk.codesync.CodeSyncLogger;
 import org.intellij.sdk.codesync.utils.CommonUtils;
 import org.intellij.sdk.codesync.utils.CodeSyncDateUtils;
 import org.intellij.sdk.codesync.utils.FileUtils;
@@ -13,6 +14,7 @@ import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.json.simple.parser.ParseException;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.scanner.ScannerException;
 
 import static org.intellij.sdk.codesync.Constants.DIFF_SIZE_LIMIT;
 
@@ -28,9 +30,14 @@ public class DiffFile {
     public DiffFile(@NotNull File originalDiffFile) {
         this.originalDiffFile = originalDiffFile;
         this.contents = FileUtils.readFileToString(originalDiffFile);
-
+        Map<String, Object> obj;
         Yaml yaml = new Yaml();
-        Map<String, Object> obj = yaml.load(this.contents);
+        try {
+            obj = yaml.load(this.contents);
+        } catch (ScannerException e) {
+            CodeSyncLogger.debug(String.format("Invalid diff file. File Contents: %s", this.contents));
+            return;
+        }
 
         this.diff = (String) obj.get("diff");
         this.branch = (String) obj.get("branch");

--- a/src/main/java/org/intellij/sdk/codesync/utils/DiffUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/utils/DiffUtils.java
@@ -69,10 +69,12 @@ public class DiffUtils {
         FileWriter writer = null;
         try {
             writer = new FileWriter(diffFilePath.toFile());
+            yaml.dump(data, writer);
+            writer.flush();
+            writer.close();
         } catch (IOException e) {
             CodeSyncLogger.error(String.format("Error writing to diff file. Error: %s", e.getMessage()));
             e.printStackTrace();
         }
-        yaml.dump(data, writer);
     }
 }

--- a/src/main/java/org/intellij/sdk/codesync/utils/DiffUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/utils/DiffUtils.java
@@ -65,10 +65,9 @@ public class DiffUtils {
 
         Yaml yaml = new Yaml(options);
         Path diffFilePath = Paths.get(DIFFS_REPO, String.format("%s.yml", System.currentTimeMillis()));
-        // Write diff file
-        FileWriter writer = null;
         try {
-            writer = new FileWriter(diffFilePath.toFile());
+            // Write diff file
+            FileWriter writer = new FileWriter(diffFilePath.toFile());
             yaml.dump(data, writer);
             writer.flush();
             writer.close();


### PR DESCRIPTION
__Description:__

Here is a list of changes included in this PR
-  Added synchronization logic for writes to config files, a locking mechanism would allow multiple threads write to the config file.
- Added handling for invalid config files, config file will be emptied if its contents are not valid.
- Changes for inactive repositories would be ignored now, previously diff files were being created causing buffer size increase.
- Offline changes for inactive repositories will be ignored.
- Updated logic to use correct initial values for fields such as `isDisconnected`, `pauseNotification` and `isDeleted` for newly synced repos.

**Testing Instructions:**
1. Manually add some invalid yaml content in the `config.yml` file and make sure file contents are removed and user is prompted to sync the repo again.
2. Open a repo that is not actively being synced, (either disconnected repo or a repo that is not yet synced) and make sure diff files are not created for this repo.
3. Sync a new repo and make sure  `isDisconnected`, `pauseNotification` and `isDeleted` are set to `false`.