### PR TITLE
Skip Healthcheck test and don't send user data in post request in Authenticator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.20.4] - 2023-04-25 (NOT DEPLOYED)
+- Skip Healthcheck Test and when server is down shows connection error in bufferHandler catch block.
+- Don't send user data on post request in Authenticator as token is already provided.
+
 ## [3.20.3] - 2023-04-21
 - Added tests for config file updates, updated logic so that async writes and locking wait do not cause the loss of data added in previous writes.
 - Added more error handling for cloud watch logs so that it gracefully handles errors and does not interrupt users.

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'com.codesync'
-version '3.20.3'
+version '3.20.4'
 
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"

--- a/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
@@ -122,6 +122,9 @@ public class HandleBuffer {
                     HandleBuffer.handleBuffer(project);
                 } catch (Exception e) {
                     CodeSyncLogger.error(String.format("handleBuffer exited with error: %s", e.getMessage()));
+                    if(e.getMessage().contains("Connection failed")){
+                        CodeSyncLogger.critical(CONNECTION_ERROR_MESSAGE);
+                    }
                 }
 
                 bufferHandler(timer, project);
@@ -171,10 +174,6 @@ public class HandleBuffer {
         }
 
         CodeSyncClient client = new CodeSyncClient();
-        if (!client.isServerUp()) {
-            CodeSyncLogger.critical(CONNECTION_ERROR_MESSAGE);
-            return;
-        }
 
         diffFiles = Arrays.copyOfRange(
             diffFiles, 0, diffFiles.length >= DIFFS_PER_ITERATION ? DIFFS_PER_ITERATION : diffFiles.length

--- a/src/main/java/org/intellij/sdk/codesync/auth/Authenticator.java
+++ b/src/main/java/org/intellij/sdk/codesync/auth/Authenticator.java
@@ -63,7 +63,7 @@ public class Authenticator extends HttpServlet {
         JSONObject jsonResponse;
 
         try {
-            jsonResponse = ClientUtils.sendPost(API_USERS, payload, accessToken).getJsonResponse();
+            jsonResponse = ClientUtils.sendPost(API_USERS, accessToken).getJsonResponse();
         } catch (RequestError | InvalidJsonError error) {
             CodeSyncLogger.critical(
                     String.format("[INTELLIJ_AUTH_ERROR]: Error while creating the user. access token: '%s'", accessToken)

--- a/src/main/java/org/intellij/sdk/codesync/clients/ClientUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/clients/ClientUtils.java
@@ -130,6 +130,10 @@ public class ClientUtils {
         }
     }
 
+    public static JSONResponse sendPost(String url, String accessToken) throws RequestError, InvalidJsonError {
+        return sendPost(url, new JSONObject(), accessToken);
+    }
+
     public static JSONResponse sendPost(String url, JSONObject payload) throws RequestError, InvalidJsonError {
         return sendPost(url, payload, null);
     }

--- a/src/test/java/org/intellij/sdk/codesync/clients/ClientUtilsTest.kt
+++ b/src/test/java/org/intellij/sdk/codesync/clients/ClientUtilsTest.kt
@@ -1,0 +1,21 @@
+package org.intellij.sdk.codesync.clients
+
+import org.intellij.sdk.codesync.Constants
+import org.intellij.sdk.codesync.clients.ClientUtils
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ClientUtilsTest {
+
+    @Test
+    fun sendPost(){
+        //TODO Add mocking
+        val correctAPI = String.format("%s/users?&source=%s&v=%s", "https://api.codesync.com/v1", "intellij", "unknown")
+        assertEquals(401, ClientUtils.sendPost(correctAPI, "ACCESS_TOKEN").statusCode)
+    }
+
+}


### PR DESCRIPTION
- Post request will not send user data when creating new user.
[ ] To test this, sign in using existing user and new user and test file synchronization for both accounts.
- Avoiding healthcheck test and printing connection error logs in bufferHandler instead.
[ ] To test this, you need to make your server down and see if "Connection Error" message is being showen after every few seconds of interval.