### PR TITLE
Added flag to disable connect button when repo being synchronized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.20.4] - 2023-04-25 (NOT DEPLOYED)
+## [3.21.0] - 2023-04-25 (NOT DEPLOYED)
+- Disable Connect Repo button when repository is in process of being connected and uploaded.
 - Skip Healthcheck Test and when server is down shows connection error in bufferHandler catch block.
 - Don't send user data on post request in Authenticator as token is already provided.
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'com.codesync'
-version '3.20.4'
+version '3.21.0'
 
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"

--- a/src/main/java/org/intellij/sdk/codesync/CodeSyncLogger.java
+++ b/src/main/java/org/intellij/sdk/codesync/CodeSyncLogger.java
@@ -5,6 +5,7 @@ import org.intellij.sdk.codesync.utils.CommonUtils;
 import org.intellij.sdk.codesync.utils.ProjectUtils;
 import org.json.simple.JSONObject;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.model.CloudWatchException;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
@@ -91,6 +92,9 @@ public class CodeSyncLogger {
                 nextSequenceToken = error.expectedSequenceToken();
             } catch (DataAlreadyAcceptedException error) {
                 nextSequenceToken = error.expectedSequenceToken();
+            } catch (SdkClientException error){
+                System.out.println("Network Error: " + error.getMessage());
+                return;
             }
 
             logConsoleMessage("Successfully put CloudWatch log event");

--- a/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
+++ b/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
@@ -126,6 +126,8 @@ public class CodeSyncSetup {
     }
 
     public static void setupCodeSyncRepoAsync(Project project, String repoPath, String repoName, boolean skipSyncPrompt, boolean isSyncingBranch) {
+        PluginState pluginState = StateUtils.getState(repoPath);
+        pluginState.syncInProcess = true;
         ProgressManager.getInstance().run(new Task.Backgroundable(project, "Initializing repo"){
             public void run(@NotNull ProgressIndicator progressIndicator) {
                 progressIndicator.setIndeterminate(false);
@@ -138,6 +140,7 @@ public class CodeSyncSetup {
 
                 // Finished
                 codeSyncProgressIndicator.setMileStone(InitRepoMilestones.END);
+                pluginState.syncInProcess = false;
             }
         });
     }

--- a/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetupAction.java
+++ b/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetupAction.java
@@ -12,6 +12,8 @@ import org.intellij.sdk.codesync.alerts.PricingAlerts;
 import org.intellij.sdk.codesync.exceptions.base.BaseException;
 import org.intellij.sdk.codesync.exceptions.base.BaseNetworkException;
 import org.intellij.sdk.codesync.exceptions.common.FileNotInModuleError;
+import org.intellij.sdk.codesync.state.PluginState;
+import org.intellij.sdk.codesync.state.StateUtils;
 import org.intellij.sdk.codesync.utils.FileUtils;
 import org.intellij.sdk.codesync.utils.ProjectUtils;
 import org.jetbrains.annotations.NotNull;
@@ -43,6 +45,11 @@ public class CodeSyncSetupAction extends BaseModuleAction {
                     presentation.setText("Connect Repo");
                     presentation.setDescription("Connect repo with codeSync");
                 }
+
+                String repoPath = ProjectUtils.getRepoPath(project);
+                PluginState pluginState = StateUtils.getState(repoPath);
+                e.getPresentation().setEnabled(!pluginState.syncInProcess);
+
             } catch (AssertionError | FileNotInModuleError error) {
                 e.getPresentation().setEnabled(false);
             }
@@ -58,6 +65,11 @@ public class CodeSyncSetupAction extends BaseModuleAction {
                 presentation.setText("Connect Repo");
                 presentation.setDescription("Connect repo with codeSync");
             }
+
+            String repoPath = ProjectUtils.getRepoPath(project);
+            PluginState pluginState = StateUtils.getState(repoPath);
+            e.getPresentation().setEnabled(!pluginState.syncInProcess);
+
         } else {
             e.getPresentation().setEnabled(false);
         }

--- a/src/main/java/org/intellij/sdk/codesync/state/PluginState.java
+++ b/src/main/java/org/intellij/sdk/codesync/state/PluginState.java
@@ -8,4 +8,5 @@ public class PluginState {
     public boolean isRepoInSync;
     public String repoPath;
     public String userEmail = null;
+    public boolean syncInProcess = false;
 }


### PR DESCRIPTION
"Connect" button will get disabled when repository is in process of being connected and getting uploaded to server. This will avoid repeated initialization of same action. Previously, "Connect" button was being disabled permanently when repo was not being connected successfully due to access token or network error. To fix this, I have added try catch block to deal with it.

- To test this for ideal situation, you can run it normally and can see it will will disable the "Connect" button once you have clicked it until repo is being connected.

- To test this for network error, you can put breakpoints in getUser() or uploadRepo() methods of CodeSyncClient class and make your server down at those points. You will observe "Connect" button will get enabled after showing failure message.