### PR TITLE
Sending diffs to server when starting up offline.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.22.1] - 2023-06-02
+- Fixed diffs not being sent to server after getting online when synced projects has started without internet.
+
 ## [3.22.0] - 2023-05-25
 - Removed UserPlan and User class and their usages.
+- Fixed synced project not opening when internet connection is not available.
 - Migrated to SQLite implementation for User info from user.yml files.
 
 ## [3.21.0] - 2023-04-25

--- a/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
@@ -154,6 +154,7 @@ public class HandleBuffer {
 
         CodeSyncClient codeSyncClient = new CodeSyncClient();
         if (!codeSyncClient.isServerUp()) {
+            diffFilesBeingProcessed.clear();
             return;
         }
 

--- a/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
@@ -152,6 +152,11 @@ public class HandleBuffer {
             return;
         }
 
+        CodeSyncClient codeSyncClient = new CodeSyncClient();
+        if (!codeSyncClient.isServerUp()) {
+            return;
+        }
+
         try {
             configFile = new ConfigFile(CONFIG_PATH);
         } catch (InvalidConfigFileError error) {


### PR DESCRIPTION
We are populating `diffFilesBeingProcessed` hashset and `diffsToSend`  list in same forEach loop. `diffFilesBeingProcessed` contains filepaths and `diffsToSend` contains diffs which are being added to this list after going through several filters. 

Previously, when we were trying to send diff files to server but we could not due to connection issue, the `diffsToSend` was getting depopulated because this list is locally declared in `bufferHandler` method but `diffFilesBeingProcessed` was not being depopulated because it is associated with class. So, when next time `bufferHandler` method was being called `diffsToSend` was not being repopulated because as I already mentioned earlier `diffFilesBeingProcessed` hashset and `diffsToSend`  were being populated in same forEach loop. As diffs were already present in `diffFilesBeingProcessed` so we could not add them to `diffsToSend` also. 

To fix this what I have done is that we need to process the diffs (adding them to `diffFilesBeingProcessed` and filtering out and then adding them to `diffsToSend`) only when we are connected to internet and if we face connection interruption during sending diffs to server we can just clear the `diffFilesBeingProcessed` and let the diffs get reprocessed once connection is resumed.

**Testing Instructions**

- When we are not connected to internet and you are making changes you will not notice following logs `Processing diff file :..` and when you will get connected back to internet then you will notice the logs `Processing diff file...` because diffs are being processed only when we are connected.