### PR TITLE
fix: Fixed a bug that was causing offline changes to have incorrect associated time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.22.1] - 2023-06-02
+## [3.22.1] - 2023-06-07
 - Fixed diffs not being sent to server after getting online when synced projects has started without internet.
+- Fixed a bug that was causing offline changes to have incorrect associated time.
 
 ## [3.22.0] - 2023-05-25
 - Removed UserPlan and User class and their usages.

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'com.codesync'
-version '3.22.0'
+version '3.22.1'
 
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"

--- a/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
@@ -443,13 +443,13 @@ public class PopulateBuffer {
             if (!diff.isEmpty() || isNewFile) {
                 Map<String, Object> diffContentMap = new HashMap<>();
                 Map<String, Object> fileInfo = this.fileInfoMap.get(relativeFilePath);
-                Date createdAt = CodeSyncDateUtils.parseDate((String) fileInfo.get("creationTime"));
+                Date modifiedTime = CodeSyncDateUtils.parseDate((String) fileInfo.get("modifiedTime"));
 
                 diffContentMap.put("diff", diff);
                 diffContentMap.put("is_rename", isRename);
                 diffContentMap.put("is_new_file", isNewFile);
                 diffContentMap.put("is_binary", isBinary);
-                diffContentMap.put("created_at", CodeSyncDateUtils.formatDate(createdAt, DATE_TIME_FORMAT));
+                diffContentMap.put("created_at", CodeSyncDateUtils.formatDate(modifiedTime, DATE_TIME_FORMAT));
 
                 diffs.put(relativeFilePath, diffContentMap);
             }


### PR DESCRIPTION
If user makes some change outside the IDE with CodeSync plugin, the populate buffer handles those changes. But it was using files creation time as the diff creation time which is incorrect and should be using file's modification time. This PR fixes that.

__Testing Instructions:__
1. In a repo that is already being synced with CodeSync, close the IDE with the CodeSync plugin.
2. Open the repo in some IDE that does not have CodeSync plugin and make some changes to some already tracked file.
3. Now, open the IDE with the CodeSync plugin and give it some time to sync up the external changes.
4. Make sure the file changes have correct values in `created_at` column of `file_history` table. 
5. If DB access is not possible then make sure the changes are appearing in the correct date range on the web interface.
