### PR TITLE
Data size being sent to server over websocket shouldn’t exceed 16MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.22.2] - 2023-06-08 (NOT DEPLOYED)
+- Put check for batch size of diffs being sent in a request should not exceed 16mb.
+
 ## [3.22.1] - 2023-06-07
 - Fixed diffs not being sent to server after getting online when synced projects has started without internet.
 - Fixed a bug that was causing offline changes to have incorrect associated time.

--- a/src/main/java/org/intellij/sdk/codesync/Constants.java
+++ b/src/main/java/org/intellij/sdk/codesync/Constants.java
@@ -101,7 +101,7 @@ public final class Constants {
     public static final Integer FILE_SIZE_AS_COPY = 100;  // 100 bytes;
     public static final double SEQUENCE_MATCHER_RATIO = 0.8; // 80% match ratio.
 
-    public static final Integer DIFF_SIZE_LIMIT = 16 * 1000 * 1000;
+    public static final Integer DIFF_SIZE_LIMIT = 15 * 1000 * 1000;
 
     public static final String SYNC_IGNORE_COMMENT = "# CodeSync won't sync the files in the .syncignore. It follows same format as .gitignore.";
 

--- a/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/HandleBuffer.java
@@ -141,6 +141,7 @@ public class HandleBuffer {
     public static void handleBuffer(Project project) {
         ConfigFile configFile;
         HashSet<String> newFiles = new HashSet<>();
+        int diffsSize = 0;
 
         boolean canRunDaemon = ProjectUtils.canRunDaemon(
             LockFileType.HANDLE_BUFFER_LOCK,
@@ -200,9 +201,17 @@ public class HandleBuffer {
                 System.out.printf("Skipping diff file: %s.\n", diffFile.originalDiffFile.getPath());
                 // Skip this file.
                 continue;
-            } else {
-                diffFilesBeingProcessed.add(diffFile.originalDiffFile.getPath());
             }
+
+            if(diffFile.diff != null)
+                diffsSize += diffFile.diff.length();
+
+            if(diffsSize > DIFF_SIZE_LIMIT){
+                CodeSyncLogger.info("Limit reached for diff batch size, remaining diffs will be processed in next request.");
+                break;
+            }
+
+            diffFilesBeingProcessed.add(diffFile.originalDiffFile.getPath());
 
             System.out.printf("Processing diff file: %s.\n", diffFile.originalDiffFile.getPath());
 


### PR DESCRIPTION
On every handleBuffer call, total size of each processed diffs is being calculated and if it is exceeding 15MB then remaining diffs are being skipped and processed diffs are sent to server. Remaining diffs are being sent to server in next call of handleBuffer.

**Testing Instructions**

- Change the size of DIFF_SIZE_LIMIT to 500 in Constants.java
- Type around 10 to 20 characters in one go.
- You will notice log `Limit reached for diff batch size, remaining diffs will be processed in next request.` after several logs of `Processing diff file: ...`
- After 5 seconds you will again see logs `Processing diff file: ...` for processing remaining diffs.
- You can verify the results by watching the playback.