### PR TITLE
Fixed websocket getting null issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented Mocking for testing static method calls in getOS and sendPost methods.
 - Updated Git workflows to build and test on all three operating systems Windows, MacOS and Linux
 - Update playback picture on GitHub repository in README.md file.
+- Fixed websocket was getting null when server was restarting.
 
 ## [3.22.2] - 2023-06-20
 - Put check for batch size of diffs being sent in a request should not exceed 16mb.

--- a/src/main/java/org/intellij/sdk/codesync/clients/CodeSyncWebSocketClient.java
+++ b/src/main/java/org/intellij/sdk/codesync/clients/CodeSyncWebSocketClient.java
@@ -26,6 +26,14 @@ public class CodeSyncWebSocketClient {
     boolean isConnected = false;
     String token = null;
 
+    boolean isConnected(){
+        if(isConnected && this.webSocketClientEndpoint.userSession != null){
+            return true;
+        }
+
+        return false;
+    }
+
     public CodeSyncWebSocketClient(String token, String uri) {
         try {
             this.token = token;
@@ -43,7 +51,7 @@ public class CodeSyncWebSocketClient {
             return;
         }
 
-        if (!this.isConnected) {
+        if (!this.isConnected()) {
             this.webSocketClientEndpoint = new WebSocketClientEndpoint(this.uri);
             this.authenticate(isAuthenticated -> {
                 this.isConnected = isAuthenticated;
@@ -91,7 +99,7 @@ public class CodeSyncWebSocketClient {
     }
 
     public void sendDiff(DiffFile diffFile, Integer fileId, DataTransmissionHandler dataTransmissionHandler) throws WebSocketConnectionError {
-        if (!this.isConnected) {
+        if (!this.isConnected()) {
             throw new WebSocketConnectionError(
                 String.format("Failed to connect to the websocket endpoint at '%s'.}", this.uri.toString())
             );
@@ -142,7 +150,7 @@ public class CodeSyncWebSocketClient {
     }
 
     public void sendDiffs(ArrayList<Pair<Integer, DiffFile>> diffsToSend, DataTransmissionHandler dataTransmissionHandler) throws WebSocketConnectionError {
-        if (!this.isConnected) {
+        if (!this.isConnected()) {
             throw new WebSocketConnectionError(
                 String.format("Failed to connect to the websocket endpoint at '%s'.", this.uri.toString())
             );


### PR DESCRIPTION
WebSocket was not opening again when server was restarting. Previously, when WebSocket was closing we were setting WebSocket instance to null and it was being reused. Now there is a check which would see if WebSocket is null then it should create a new instance.

**Test Instructions**

1. Open a synced project and and make changes, now check in IDE logs if WebSocket connection has opened successfully and see if diffs are being processed and sent in logs. 

2. Now restart the server while your project is open. You will notice log in IDE about WebSocket being closed. After performing the server restart, perform the exercise in instruction 1 again.