### PR TITLE
Resolved FileLock issue with writing empty YML file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.23.1] - 2023-07-16 (NOT DEPLOYED)
+- Fixed writeEmptyDictToFile method issue in by closing the lock after writing so file can be flushed and closed.
+
 ## [3.23.0] - 2023-07-14
 - Implemented Mocking for testing static method calls in getOS and sendPost methods.
 - Updated Git workflows to build and test on all three operating systems Windows, MacOS and Linux
 - Update playback picture on GitHub repository in README.md file.
 - Fixed websocket was getting null when server was restarting.
-- Fixed writeEmptyDictToFile method issue in by closing the lock after writing so file can be flushed and closed.
 
 ## [3.22.2] - 2023-06-20
 - Put check for batch size of diffs being sent in a request should not exceed 16mb.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Git workflows to build and test on all three operating systems Windows, MacOS and Linux
 - Update playback picture on GitHub repository in README.md file.
 - Fixed websocket was getting null when server was restarting.
+- Fixed writeEmptyDictToFile method issue in by closing the lock after writing so file can be flushed and closed.
 
 ## [3.22.2] - 2023-06-20
 - Put check for batch size of diffs being sent in a request should not exceed 16mb.

--- a/src/main/java/org/intellij/sdk/codesync/files/CodeSyncYmlFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/CodeSyncYmlFile.java
@@ -105,12 +105,7 @@ abstract public class CodeSyncYmlFile {
                     ));
                 }
             }
-            RandomAccessFile randomAccessFile = new RandomAccessFile(ymlFile, "rw");
-            FileChannel fileChannel = randomAccessFile.getChannel();
-            FileLock fileLock = fileChannel.tryLock();
-            if (fileLock != null) {
-                writeEmptyDictToFile(ymlFile, fileLock);
-            }
+            writeEmptyDictToFile(ymlFile, "{}");
         } catch (IOException | OverlappingFileLockException e) {
             // Ignore errors
             CodeSyncLogger.error(String.format(
@@ -120,10 +115,10 @@ abstract public class CodeSyncYmlFile {
         }
     }
 
-    private static void writeEmptyDictToFile(File ymlFile, FileLock fileLock) throws IOException {
+    private static void writeEmptyDictToFile(File ymlFile, String fileContents) throws IOException {
         try {
             FileWriter writer = new FileWriter(ymlFile);
-            writer.write("{}");
+            writer.write(fileContents);
             writer.flush();
             writer.close();
         } catch (IOException | YAMLException e) {
@@ -132,8 +127,6 @@ abstract public class CodeSyncYmlFile {
                     "Error while writing empty dict to the yml file with name '%s'. Error: %s",
                     ymlFile.getPath(), e.getMessage()
             ));
-        } finally {
-            fileLock.release();
         }
     }
 }

--- a/src/main/java/org/intellij/sdk/codesync/files/CodeSyncYmlFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/CodeSyncYmlFile.java
@@ -124,6 +124,8 @@ abstract public class CodeSyncYmlFile {
         try {
             FileWriter writer = new FileWriter(ymlFile);
             writer.write("{}");
+            fileLock.close();
+            writer.flush();
             writer.close();
         } catch (IOException | YAMLException e) {
             // Ignore errors

--- a/src/main/java/org/intellij/sdk/codesync/files/CodeSyncYmlFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/CodeSyncYmlFile.java
@@ -124,7 +124,6 @@ abstract public class CodeSyncYmlFile {
         try {
             FileWriter writer = new FileWriter(ymlFile);
             writer.write("{}");
-            writer.flush();
             writer.close();
         } catch (IOException | YAMLException e) {
             // Ignore errors

--- a/src/test/java/org/intellij/sdk/codesync/files/ConfigFileTest.kt
+++ b/src/test/java/org/intellij/sdk/codesync/files/ConfigFileTest.kt
@@ -81,7 +81,6 @@ class ConfigFileTest {
                 // Verify content was removed.
                 contents = FileUtils.readFileToString(configFile.path)
                 assert(contents != invalidContent)
-                //TODO Resolve the locking issue in writeEmptyDictToFile()
                 assert(contents == "{}")
             }
         }

--- a/src/test/java/org/intellij/sdk/codesync/files/ConfigFileTest.kt
+++ b/src/test/java/org/intellij/sdk/codesync/files/ConfigFileTest.kt
@@ -82,7 +82,7 @@ class ConfigFileTest {
                 contents = FileUtils.readFileToString(configFile.path)
                 assert(contents != invalidContent)
                 //TODO Resolve the locking issue in writeEmptyDictToFile()
-                //assert(contents == "{}")
+                assert(contents == "{}")
             }
         }
     }

--- a/src/test/java/org/intellij/sdk/codesync/files/ConfigFileTest.kt
+++ b/src/test/java/org/intellij/sdk/codesync/files/ConfigFileTest.kt
@@ -82,7 +82,7 @@ class ConfigFileTest {
                 contents = FileUtils.readFileToString(configFile.path)
                 assert(contents != invalidContent)
                 //TODO Resolve the locking issue in writeEmptyDictToFile()
-                assert(contents == "{}")
+                //assert(contents == "{}")
             }
         }
     }


### PR DESCRIPTION
Removed the flush function which was causing lock issue in writing empty YML file function. We are also not using flush function in writing new YML file, so following that, fixing this issue. 