### PR TITLE
Checks for LockFile expiry, text in YML file reading and fileContent variable getting null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.23.1] - 2023-07-16 (NOT DEPLOYED)
 - Fixed writeEmptyDictToFile method issue in by closing the lock after writing so file can be flushed and closed.
 - Put check for LockFile expiry getting null and text getting null while reading YML file
-- fileContents variable should return empty value in case of file reading exception instead of null
+- put check for fileContent variable if it is null
 
 ## [3.23.0] - 2023-07-14
 - Implemented Mocking for testing static method calls in getOS and sendPost methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.23.1] - 2023-07-16 (NOT DEPLOYED)
 - Fixed writeEmptyDictToFile method issue in by closing the lock after writing so file can be flushed and closed.
 - Put check for LockFile expiry getting null and text getting null while reading YML file
+- fileContents variable should return empty value in case of file reading exception instead of null
 
 ## [3.23.0] - 2023-07-14
 - Implemented Mocking for testing static method calls in getOS and sendPost methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.23.1] - 2023-07-16 (NOT DEPLOYED)
 - Fixed writeEmptyDictToFile method issue in by closing the lock after writing so file can be flushed and closed.
+- Put check for LockFile expiry getting null and text getting null while reading YML file
 
 ## [3.23.0] - 2023-07-14
 - Implemented Mocking for testing static method calls in getOS and sendPost methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.23.1] - 2023-07-16 (NOT DEPLOYED)
+## [3.23.1] - 2023-07-25
 - Fixed writeEmptyDictToFile method issue in by closing the lock after writing so file can be flushed and closed.
-- Put check for LockFile expiry getting null and text getting null while reading YML file
-- put check for fileContent variable if it is null
+- Put check for LockFile expiry getting null and text getting null while reading YML file.
+- put check for fileContent variable if it is null and send logs to cloud watch for that file.
 
 ## [3.23.0] - 2023-07-14
 - Implemented Mocking for testing static method calls in getOS and sendPost methods.

--- a/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
@@ -475,7 +475,7 @@ public class PopulateBuffer {
             renameResult.put("shadowFilePath", matchingFilePath);
 
             if(fileContents == null){
-                CodeSyncLogger.error(String.format("File content was returned as null for file: ", filePath));
+                CodeSyncLogger.error(String.format("File content was returned as null for file: %s", filePath));
             }
 
             return renameResult;

--- a/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
@@ -470,7 +470,7 @@ public class PopulateBuffer {
 
         String fileContents = FileUtils.readFileToString(filePath);
 
-        if (fileContents.isEmpty()) {
+        if (fileContents == null || fileContents.isEmpty()) {
             renameResult.put("isRename", false);
             renameResult.put("shadowFilePath", matchingFilePath);
 

--- a/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
+++ b/src/main/java/org/intellij/sdk/codesync/PopulateBuffer.java
@@ -474,6 +474,10 @@ public class PopulateBuffer {
             renameResult.put("isRename", false);
             renameResult.put("shadowFilePath", matchingFilePath);
 
+            if(fileContents == null){
+                CodeSyncLogger.error(String.format("File content was returned as null for file: ", filePath));
+            }
+
             return renameResult;
         }
 

--- a/src/main/java/org/intellij/sdk/codesync/files/CodeSyncYmlFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/CodeSyncYmlFile.java
@@ -38,6 +38,8 @@ abstract public class CodeSyncYmlFile {
             throw new InvalidYmlFileError(e.getMessage());
         } catch (IOException e) {
             throw new FileNotFoundException(e.getMessage());
+        } catch (NullPointerException e){
+            throw new FileNotFoundException(e.getMessage());
         }
     }
 

--- a/src/main/java/org/intellij/sdk/codesync/files/LockFile.java
+++ b/src/main/java/org/intellij/sdk/codesync/files/LockFile.java
@@ -72,6 +72,9 @@ public class LockFile extends CodeSyncYmlFile {
 
         public boolean isActive () {
             // return true if `this.expiry` is in the future.
+            if(this.expiry == null)
+                return false;
+
             return this.expiry.isAfter(Instant.now());
         }
 

--- a/src/main/java/org/intellij/sdk/codesync/utils/FileUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/utils/FileUtils.java
@@ -38,7 +38,7 @@ public class FileUtils
             return org.apache.commons.io.FileUtils.readFileToString(file, StandardCharsets.UTF_8);
         } catch (IOException e) {
             CodeSyncLogger.error(String.format("Could not read file '%s'. Error: %s", file.getPath(), e.getMessage()));
-            return null;
+            return "";
         }
     }
 

--- a/src/main/java/org/intellij/sdk/codesync/utils/FileUtils.java
+++ b/src/main/java/org/intellij/sdk/codesync/utils/FileUtils.java
@@ -38,7 +38,7 @@ public class FileUtils
             return org.apache.commons.io.FileUtils.readFileToString(file, StandardCharsets.UTF_8);
         } catch (IOException e) {
             CodeSyncLogger.error(String.format("Could not read file '%s'. Error: %s", file.getPath(), e.getMessage()));
-            return "";
+            return null;
         }
     }
 


### PR DESCRIPTION
Put checks for following issues.

`v3.20.2: handleBuffer exited with error: Cannot invoke "String.length()" because "text" is null` 
in file `CodeSyncYmlFile.java`

`populateBuffer exited with error: Cannot invoke "java.time.Instant.isAfter(java.time.Instant)" because "this.expiry" is null` 
in file `LockFile.java`

`populateBuffer exited with error: Cannot invoke "String.isEmpty()" because "fileContents" is null` 
in file `PopulateBuffer.java`
