### PR TITLE
fix: Reload state to make sure the plugin is in the correct state after the repo sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.31.4] 2024-02-23
+- Reload state to make sure the plugin is in the correct state after the repo sync.
+
 ## [3.31.3] 2024-01-29
 - Disabled config file reset logic in case of yaml error.
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'com.codesync'
-version '3.31.3'
+version '3.31.4'
 
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"

--- a/src/main/java/org/intellij/sdk/codesync/ProjectOpenCloseListener.java
+++ b/src/main/java/org/intellij/sdk/codesync/ProjectOpenCloseListener.java
@@ -131,7 +131,7 @@ public class ProjectOpenCloseListener implements ProjectManagerListener {
       public void after(@NotNull List<? extends VFileEvent> events) {
         String repoPath;
 
-        // Abort if account is has been deactivated.
+        // Abort if account has been deactivated.
         if (StateUtils.getGlobalState().isAccountDeactivated) {
           return;
         }

--- a/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
+++ b/src/main/java/org/intellij/sdk/codesync/codeSyncSetup/CodeSyncSetup.java
@@ -193,8 +193,9 @@ public class CodeSyncSetup {
                 // Finished
                 codeSyncProgressIndicator.setMileStone(InitRepoMilestones.END);
                 
-                // Update state to show repo is in sync with the server.
-                StateUtils.updateRepoStatus(repoPath, RepoStatus.IN_SYNC);
+                // Reload state according to the current state.
+                // We are reloading here instead of marking it as Done because we want to make sure the state is correct.
+                StateUtils.reloadState(project);
             }
         });
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -107,6 +107,7 @@
         <li>Updated messaging for repo disconnect confirmation prompt.</li>
         <li>Only process diffs of the authenticated user.</li>
         <li>Disabled config file reset logic in case of yaml error.</li>
+        <li>Reload state to make sure the plugin is in the correct state after the repo sync:.</li>
       </ul>
     ]]>
   </change-notes>


### PR DESCRIPTION
This PR makes sure to reload state after repo sync so that state is in correct state after.

**Testing Instructions:**
1. Open a repo that is not being synced.
2. Wait for the popup that asks to sync the repo and click "No" when it appears.
3. Go to the "CodeSync" menu and make sure the there is entry for "Connect Repo" and clicking it starts the repo syncing process.



