### PR TITLE
Improvement: Showing alerts for invalid projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.0] - 2025-09-09
+- Disables CodeSync group if an invalid project is opened
+
 ## [4.8.0] - 2025-03-11
 - Modified video link in README and plugin.xml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.9.0] - 2025-09-09
+## [4.9.0] - 2025-09-25
 - Disables CodeSync group if an invalid project is opened
 
 ## [4.8.0] - 2025-03-11

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.codesync'
-version '4.8.0'
+version '4.9.0'
 
 
 compileJava.options.encoding = "UTF-8"

--- a/src/main/java/org/intellij/sdk/codesync/CodeSyncStartupActivity.java
+++ b/src/main/java/org/intellij/sdk/codesync/CodeSyncStartupActivity.java
@@ -34,20 +34,13 @@ import static org.intellij.sdk.codesync.Constants.FILE_RENAME_EVENT;
 import static org.intellij.sdk.codesync.Utils.*;
 import static org.intellij.sdk.codesync.Utils.ChangesHandler;
 import static org.intellij.sdk.codesync.codeSyncSetup.CodeSyncSetup.createSystemDirectories;
+import org.intellij.sdk.codesync.state.StateUtils;
+import org.intellij.sdk.codesync.state.PluginState;
 
 public class CodeSyncStartupActivity implements StartupActivity {
 
     @Override
     public void runActivity(@NotNull Project project) {
-
-        String basePath = project.getBasePath();
-        if (basePath.startsWith("/tmp/")) {
-            Messages.showInfoMessage(
-                    AlertMessages.INVALID_PROJECT,
-                    AlertTitles.INVALID_PROJECT
-            );
-            return;
-        }
         // Create system directories required by the plugin.
         createSystemDirectories();
         String repoDirPath = ProjectUtils.getRepoPath(project);

--- a/src/main/java/org/intellij/sdk/codesync/CodeSyncStartupActivity.java
+++ b/src/main/java/org/intellij/sdk/codesync/CodeSyncStartupActivity.java
@@ -24,6 +24,7 @@ import org.intellij.sdk.codesync.utils.CommonUtils;
 import org.intellij.sdk.codesync.utils.FileUtils;
 import org.intellij.sdk.codesync.utils.ProjectUtils;
 import org.jetbrains.annotations.NotNull;
+import com.intellij.openapi.ui.Messages;
 
 import java.io.IOException;
 import java.util.List;
@@ -38,6 +39,15 @@ public class CodeSyncStartupActivity implements StartupActivity {
 
     @Override
     public void runActivity(@NotNull Project project) {
+
+        String basePath = project.getBasePath();
+        if (basePath.startsWith("/tmp/")) {
+            Messages.showInfoMessage(
+                    AlertMessages.INVALID_PROJECT,
+                    AlertTitles.INVALID_PROJECT
+            );
+            return;
+        }
         // Create system directories required by the plugin.
         createSystemDirectories();
         String repoDirPath = ProjectUtils.getRepoPath(project);

--- a/src/main/java/org/intellij/sdk/codesync/CodeSyncStartupActivity.java
+++ b/src/main/java/org/intellij/sdk/codesync/CodeSyncStartupActivity.java
@@ -24,7 +24,6 @@ import org.intellij.sdk.codesync.utils.CommonUtils;
 import org.intellij.sdk.codesync.utils.FileUtils;
 import org.intellij.sdk.codesync.utils.ProjectUtils;
 import org.jetbrains.annotations.NotNull;
-import com.intellij.openapi.ui.Messages;
 
 import java.io.IOException;
 import java.util.List;
@@ -34,8 +33,6 @@ import static org.intellij.sdk.codesync.Constants.FILE_RENAME_EVENT;
 import static org.intellij.sdk.codesync.Utils.*;
 import static org.intellij.sdk.codesync.Utils.ChangesHandler;
 import static org.intellij.sdk.codesync.codeSyncSetup.CodeSyncSetup.createSystemDirectories;
-import org.intellij.sdk.codesync.state.StateUtils;
-import org.intellij.sdk.codesync.state.PluginState;
 
 public class CodeSyncStartupActivity implements StartupActivity {
 

--- a/src/main/java/org/intellij/sdk/codesync/Constants.java
+++ b/src/main/java/org/intellij/sdk/codesync/Constants.java
@@ -263,13 +263,9 @@ public final class Constants {
         public static final int PRIVATE_REPO_COUNT_LIMIT_REACHED = 4006;
     }
 
-    public static final class AlertTitles {
-        public static final String CODESYNC = "CodeSync";
-    }
-
-    public static final class AlertMessages {
-        public static final String OPEN_FOLDER = "In order to use CodeSync’s features, you can open a folder.";
-        public static final String ACCOUNT_DEACTIVATED = "Your account is deactivated. In order to use CodeSync’s features, please use an active account.";
+    public static final class StatusBarMessages {
+        public static final String OPEN_FOLDER = "CodeSync Information: In order to use CodeSync’s features, you can open a folder.";
+        public static final String ACCOUNT_DEACTIVATED = "CodeSync Information: Your account is deactivated. In order to use CodeSync’s features, please use an active account.";
     }
 }
 

--- a/src/main/java/org/intellij/sdk/codesync/Constants.java
+++ b/src/main/java/org/intellij/sdk/codesync/Constants.java
@@ -264,8 +264,8 @@ public final class Constants {
     }
 
     public static final class StatusBarMessages {
-        public static final String OPEN_FOLDER = "CodeSync Information: In order to use CodeSync’s features, you can open a folder.";
-        public static final String ACCOUNT_DEACTIVATED = "CodeSync Information: Your account is deactivated. In order to use CodeSync’s features, please use an active account.";
+        public static final String OPEN_FOLDER = "CodeSync notification: CodeSync only works with folders. Please open a folder to start syncing.";
+        public static final String ACCOUNT_DEACTIVATED = "CodeSync notification: Your account is deactivated. In order to use CodeSync’s features, please use an active account.";
     }
 }
 

--- a/src/main/java/org/intellij/sdk/codesync/Constants.java
+++ b/src/main/java/org/intellij/sdk/codesync/Constants.java
@@ -262,6 +262,14 @@ public final class Constants {
         public static final int IS_FROZEN_REPO = 4000;
         public static final int PRIVATE_REPO_COUNT_LIMIT_REACHED = 4006;
     }
+
+    public static final class AlertTitles {
+        public static final String INVALID_PROJECT = "CodeSync: Invalid Project detected.";
+    }
+
+    public static final class AlertMessages {
+        public static final String INVALID_PROJECT = "Please open a valid project to use CodeSync’s services.";
+    }
 }
 
 

--- a/src/main/java/org/intellij/sdk/codesync/Constants.java
+++ b/src/main/java/org/intellij/sdk/codesync/Constants.java
@@ -264,11 +264,12 @@ public final class Constants {
     }
 
     public static final class AlertTitles {
-        public static final String INVALID_PROJECT = "CodeSync: Invalid Project detected.";
+        public static final String CODESYNC = "CodeSync";
     }
 
     public static final class AlertMessages {
-        public static final String INVALID_PROJECT = "Please open a valid project to use CodeSync’s services.";
+        public static final String OPEN_FOLDER = "In order to use CodeSync’s features, you can open a folder.";
+        public static final String ACCOUNT_DEACTIVATED = "Your account is deactivated. In order to use CodeSync’s features, please use an active account.";
     }
 }
 

--- a/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
+++ b/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
@@ -62,7 +62,7 @@ public class CodeSyncActionGroup extends DefaultActionGroup {
         if (StateUtils.getGlobalState().isAccountDeactivated) {
             visible = false;
             // Display alert message
-            showStatusBarMessage(AlertMessages.ACCOUNT_DEACTIVATED, project);
+            showStatusBarMessage(StatusBarMessages.ACCOUNT_DEACTIVATED, project);
         }
 
         // Hide group if invalid project path
@@ -79,7 +79,7 @@ public class CodeSyncActionGroup extends DefaultActionGroup {
         if (!repoRoot.isDirectory()) {
             visible = false;
             // Display alert message
-            showStatusBarMessage(AlertMessages.OPEN_FOLDER, project);
+            showStatusBarMessage(StatusBarMessages.OPEN_FOLDER, project);
         }
 
         e.getPresentation().setVisible(visible);

--- a/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
+++ b/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
@@ -14,7 +14,8 @@ import org.intellij.sdk.codesync.codeSyncSetup.CodeSyncSetupAction;
 import org.intellij.sdk.codesync.utils.ProjectUtils;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import org.intellij.sdk.codesync.utils.ProjectUtils;
-
+import com.intellij.openapi.ui.Messages;
+import org.intellij.sdk.codesync.Constants.*;
 
 public class CodeSyncActionGroup extends DefaultActionGroup {
 
@@ -46,6 +47,11 @@ public class CodeSyncActionGroup extends DefaultActionGroup {
         // Hide group if account is deactivated
         if (StateUtils.getGlobalState().isAccountDeactivated) {
             visible = false;
+            // Display alert message
+            Messages.showInfoMessage(
+                    AlertMessages.ACCOUNT_DEACTIVATED,
+                    AlertTitles.CODESYNC
+            );
         }
 
         // Hide group if invalid project path
@@ -54,15 +60,18 @@ public class CodeSyncActionGroup extends DefaultActionGroup {
         }
 
         VirtualFile repoRoot = this.getRepoRoot(e, project);
-        System.out.println(repoRoot);
         if (repoRoot == null) {
             visible = false;
         }
 
         // A single file is opened, no need to sync it.
-        System.out.println(repoRoot.isDirectory());
         if (!repoRoot.isDirectory()) {
             visible = false;
+            // Display alert message
+            Messages.showInfoMessage(
+                    AlertMessages.OPEN_FOLDER,
+                    AlertTitles.CODESYNC
+            );
         }
 
         e.getPresentation().setVisible(visible);

--- a/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
+++ b/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
@@ -17,10 +17,23 @@ import org.intellij.sdk.codesync.utils.ProjectUtils;
 import com.intellij.openapi.ui.Messages;
 import org.intellij.sdk.codesync.Constants.*;
 
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.WindowManager;
+
+import org.intellij.sdk.codesync.NotificationManager;
+
 public class CodeSyncActionGroup extends DefaultActionGroup {
 
     PluginState pluginState = StateUtils.getGlobalState();
     private boolean wasAlertShown = false;
+
+    public void showStatusBarMessage(String alertMessage, Project project) {
+        StatusBar statusBar = WindowManager.getInstance().getStatusBar(project);
+        if (statusBar != null) {
+            statusBar.setInfo(alertMessage);
+        }
+    }
 
     private VirtualFile getRepoRoot(AnActionEvent anActionEvent, Project project) {
         VirtualFile[] contentRoots = ProjectUtils.getAllContentRoots(project);
@@ -49,13 +62,7 @@ public class CodeSyncActionGroup extends DefaultActionGroup {
         if (StateUtils.getGlobalState().isAccountDeactivated) {
             visible = false;
             // Display alert message
-            if (!wasAlertShown) {
-                Messages.showInfoMessage(
-                        AlertMessages.ACCOUNT_DEACTIVATED,
-                        AlertTitles.CODESYNC
-                );
-                wasAlertShown = true;
-            }
+            showStatusBarMessage(AlertMessages.ACCOUNT_DEACTIVATED, project);
         }
 
         // Hide group if invalid project path
@@ -72,13 +79,7 @@ public class CodeSyncActionGroup extends DefaultActionGroup {
         if (!repoRoot.isDirectory()) {
             visible = false;
             // Display alert message
-            if (!wasAlertShown) {
-                Messages.showInfoMessage(
-                        AlertMessages.OPEN_FOLDER,
-                        AlertTitles.CODESYNC
-                );
-                wasAlertShown = true;
-            }
+            showStatusBarMessage(AlertMessages.OPEN_FOLDER, project);
         }
 
         e.getPresentation().setVisible(visible);

--- a/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
+++ b/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
@@ -1,0 +1,71 @@
+package org.intellij.sdk.codesync.actions;
+
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.intellij.sdk.codesync.state.PluginState;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.intellij.sdk.codesync.state.StateUtils;
+import org.intellij.sdk.codesync.state.PluginState;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.intellij.sdk.codesync.codeSyncSetup.CodeSyncSetupAction;
+import org.intellij.sdk.codesync.utils.ProjectUtils;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import org.intellij.sdk.codesync.utils.ProjectUtils;
+
+
+public class CodeSyncActionGroup extends DefaultActionGroup {
+
+    PluginState pluginState = StateUtils.getGlobalState();
+
+    private VirtualFile getRepoRoot(AnActionEvent anActionEvent, Project project) {
+        VirtualFile[] contentRoots = ProjectUtils.getAllContentRoots(project);
+
+        if (contentRoots.length > 1) {
+            // If more than one module are present in the project then a file must be open to show repo setup action
+            // this is needed because without the file we can not determine the correct repo sync.
+            VirtualFile virtualFile = anActionEvent.getRequiredData(CommonDataKeys.PSI_FILE).getVirtualFile();
+            return ProjectUtils.getRepoRoot(virtualFile, project);
+        } else if (contentRoots.length == 1) {
+            // If there is only one module then we can simply show the repo playback for the only repo present.
+            // Disable the button if repo is not in sync.
+            return contentRoots[0];
+        }
+
+        return null;
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        Project project = e.getProject();
+
+        boolean visible = true;
+
+        // Hide group if account is deactivated
+        if (StateUtils.getGlobalState().isAccountDeactivated) {
+            visible = false;
+        }
+
+        // Hide group if invalid project path
+        if (project == null || (project.getBasePath() != null && project.getBasePath().startsWith("/tmp/"))) {
+            visible = false;
+        }
+
+        VirtualFile repoRoot = this.getRepoRoot(e, project);
+        System.out.println(repoRoot);
+        if (repoRoot == null) {
+            visible = false;
+        }
+
+        // A single file is opened, no need to sync it.
+        System.out.println(repoRoot.isDirectory());
+        if (!repoRoot.isDirectory()) {
+            visible = false;
+        }
+
+        e.getPresentation().setVisible(visible);
+        e.getPresentation().setEnabled(visible);
+    }
+}

--- a/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
+++ b/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
@@ -20,6 +20,7 @@ import org.intellij.sdk.codesync.Constants.*;
 public class CodeSyncActionGroup extends DefaultActionGroup {
 
     PluginState pluginState = StateUtils.getGlobalState();
+    private boolean wasAlertShown = false;
 
     private VirtualFile getRepoRoot(AnActionEvent anActionEvent, Project project) {
         VirtualFile[] contentRoots = ProjectUtils.getAllContentRoots(project);
@@ -48,10 +49,13 @@ public class CodeSyncActionGroup extends DefaultActionGroup {
         if (StateUtils.getGlobalState().isAccountDeactivated) {
             visible = false;
             // Display alert message
-            Messages.showInfoMessage(
-                    AlertMessages.ACCOUNT_DEACTIVATED,
-                    AlertTitles.CODESYNC
-            );
+            if (!wasAlertShown) {
+                Messages.showInfoMessage(
+                        AlertMessages.ACCOUNT_DEACTIVATED,
+                        AlertTitles.CODESYNC
+                );
+                wasAlertShown = true;
+            }
         }
 
         // Hide group if invalid project path
@@ -68,10 +72,13 @@ public class CodeSyncActionGroup extends DefaultActionGroup {
         if (!repoRoot.isDirectory()) {
             visible = false;
             // Display alert message
-            Messages.showInfoMessage(
-                    AlertMessages.OPEN_FOLDER,
-                    AlertTitles.CODESYNC
-            );
+            if (!wasAlertShown) {
+                Messages.showInfoMessage(
+                        AlertMessages.OPEN_FOLDER,
+                        AlertTitles.CODESYNC
+                );
+                wasAlertShown = true;
+            }
         }
 
         e.getPresentation().setVisible(visible);

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -124,7 +124,10 @@
                   topic="com.intellij.openapi.project.ProjectManagerListener"/>
     </projectListeners>
     <actions>
-        <group id="org.intellij.sdk.action.GroupedActions" text="CodeSync" popup="true"
+        <group id="org.intellij.sdk.action.GroupedActions"
+               class="org.intellij.sdk.codesync.actions.CodeSyncActionGroup"
+               text="CodeSync"
+               popup="true"
                icon="CodeSyncIcons.codeSyncIcon">
             <add-to-group group-id="MainMenu" anchor="after" relative-to-action="ToolsMenu"/>
             <add-to-group group-id="EditorPopupMenu" anchor="last"/>


### PR DESCRIPTION
## Changes
- Added constant classes `AlertMessages` and `AlertTitles` that contain alert titles and messages respectively
- Hiding `CodeSync` group for invalid projects
- Showing alert message if user opens an invalid project.
- Added a class field `wasAlertShown` so that alerts show only once in `update()`

Toolbar for an valid project (CodeSync group is displayed):
<img width="636" height="36" alt="image" src="https://github.com/user-attachments/assets/ba5902da-f09f-4414-8584-f50be1839ef6" />

Toolbar for an invalid project (CodeSync group not displayed):
<img width="534" height="43" alt="image" src="https://github.com/user-attachments/assets/0e5a8491-0f60-495f-9f16-2ad52614608e" />

Alert message for invalid project:
<img width="435" height="100" alt="image" src="https://github.com/user-attachments/assets/d36849b3-f3c3-49da-8d00-8ba801ac6de8" />

Alert message for deactivated account:
<img width="431" height="84" alt="image" src="https://github.com/user-attachments/assets/e3d8e4c6-92a4-418e-99d2-c2b12e61616e" />

