### PR TITLE
Hotfix: Early returning from `update()` if no project detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.9.0] - 2025-09-25
+## [4.9.1] - 2025-09-30
 - Disables CodeSync group if an invalid project is opened
 
 ## [4.8.0] - 2025-03-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.9.2] - 2025-10-01
+## [4.9.3] - 2025-10-06
 - Disables CodeSync group if an invalid project is opened
 
 ## [4.8.0] - 2025-03-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.9.1] - 2025-09-30
+## [4.9.2] - 2025-10-01
 - Disables CodeSync group if an invalid project is opened
 
 ## [4.8.0] - 2025-03-11

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.codesync'
-version '4.9.2'
+version '4.9.3'
 
 
 compileJava.options.encoding = "UTF-8"

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.codesync'
-version '4.9.0'
+version '4.9.1'
 
 
 compileJava.options.encoding = "UTF-8"

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.codesync'
-version '4.9.1'
+version '4.9.2'
 
 
 compileJava.options.encoding = "UTF-8"

--- a/src/main/java/org/intellij/sdk/codesync/Constants.java
+++ b/src/main/java/org/intellij/sdk/codesync/Constants.java
@@ -201,6 +201,10 @@ public final class Constants {
         public static final String ACCOUNT_DEACTIVATED = "Your account has been deactivated. Please click 'Reactivate Account' below to resume syncing.";
         public static final String ACCOUNT_REACTIVATE_BUTTON = "Reactivate Account";
         public static final String REACTIVATED_SUCCESS = "Successfully reactivated your account";
+
+        // Invalid project related notification messages
+        public static final String INVALID_PROJECT_OPEN_FOLDER = "CodeSync only works with folders. Please open a folder to start syncing.";
+        public static final String INVALID_PROJECT_ACCOUNT_DEACTIVATED = "Your account is deactivated. In order to use CodeSync’s features, please use an active account.";
     }
 
 
@@ -262,11 +266,4 @@ public final class Constants {
         public static final int IS_FROZEN_REPO = 4000;
         public static final int PRIVATE_REPO_COUNT_LIMIT_REACHED = 4006;
     }
-
-    public static final class StatusBarMessages {
-        public static final String OPEN_FOLDER = "CodeSync notification: CodeSync only works with folders. Please open a folder to start syncing.";
-        public static final String ACCOUNT_DEACTIVATED = "CodeSync notification: Your account is deactivated. In order to use CodeSync’s features, please use an active account.";
-    }
 }
-
-

--- a/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
+++ b/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.actionSystem.CommonDataKeys;
 import org.intellij.sdk.codesync.utils.ProjectUtils;
 import com.intellij.openapi.ui.Messages;
 import org.intellij.sdk.codesync.Constants.*;
+import org.intellij.sdk.codesync.NotificationManager;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.StatusBar;
@@ -57,12 +58,15 @@ public class CodeSyncActionGroup extends DefaultActionGroup {
         Project project = e.getProject();
 
         boolean visible = true;
-
         // Hide group if account is deactivated
         if (StateUtils.getGlobalState().isAccountDeactivated) {
             visible = false;
             // Display alert message
-            showStatusBarMessage(StatusBarMessages.ACCOUNT_DEACTIVATED, project);
+            NotificationManager.getInstance().notifyInformation(
+                    Notification.INVALID_PROJECT_ACCOUNT_DEACTIVATED, project
+            );
+            // Setting wasAlertShown=true so it only shows once
+            wasAlertShown = true;
         }
 
         // Hide group if invalid project path
@@ -82,7 +86,13 @@ public class CodeSyncActionGroup extends DefaultActionGroup {
             // A single file is opened, no need to sync it.
             if (!repoRoot.isDirectory()) {
                 visible = false;
-                showStatusBarMessage(StatusBarMessages.OPEN_FOLDER, project);
+                if (!wasAlertShown) {
+                    NotificationManager.getInstance().notifyInformation(
+                            Notification.INVALID_PROJECT_OPEN_FOLDER, project
+                    );
+                    // Setting wasAlertShown=true so it only shows once
+                    wasAlertShown = true;
+                }
             }
         }
         e.getPresentation().setVisible(visible);

--- a/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
+++ b/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
@@ -78,15 +78,13 @@ public class CodeSyncActionGroup extends DefaultActionGroup {
         VirtualFile repoRoot = this.getRepoRoot(e, project);
         if (repoRoot == null) {
             visible = false;
+        } else {
+            // A single file is opened, no need to sync it.
+            if (!repoRoot.isDirectory()) {
+                visible = false;
+                showStatusBarMessage(StatusBarMessages.OPEN_FOLDER, project);
+            }
         }
-
-        // A single file is opened, no need to sync it.
-        if (!repoRoot.isDirectory()) {
-            visible = false;
-            // Display alert message
-            showStatusBarMessage(StatusBarMessages.OPEN_FOLDER, project);
-        }
-
         e.getPresentation().setVisible(visible);
         e.getPresentation().setEnabled(visible);
     }

--- a/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
+++ b/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
@@ -70,6 +70,11 @@ public class CodeSyncActionGroup extends DefaultActionGroup {
             visible = false;
         }
 
+        if (project == null) {
+            presentation.setVisible(false);
+            return;
+        }
+
         VirtualFile repoRoot = this.getRepoRoot(e, project);
         if (repoRoot == null) {
             visible = false;

--- a/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
+++ b/src/main/java/org/intellij/sdk/codesync/actions/CodeSyncActionGroup.java
@@ -71,7 +71,7 @@ public class CodeSyncActionGroup extends DefaultActionGroup {
         }
 
         if (project == null) {
-            presentation.setVisible(false);
+            e.getPresentation().setVisible(visible);
             return;
         }
 


### PR DESCRIPTION
## Changes
- Early returning from `update()` if no project detected
- Displaying Balloon alert instead of Status Bar alert

## Screenshots

<img width="435" height="100" alt="image" src="https://github.com/user-attachments/assets/d36849b3-f3c3-49da-8d00-8ba801ac6de8" />

<img width="431" height="84" alt="image" src="https://github.com/user-attachments/assets/e3d8e4c6-92a4-418e-99d2-c2b12e61616e" />

